### PR TITLE
ml_dtypes.finfo: extension of np.finfo for new types.

### DIFF
--- a/ml_dtypes/__init__.py
+++ b/ml_dtypes/__init__.py
@@ -13,6 +13,14 @@
 # limitations under the License.
 
 __version__ = '0.0.3'  # Keep in sync with pyproject.toml:version
+__all__ = [
+    '__version__',
+    'bfloat16',
+    'finfo',
+    'float8_e4m3b11',
+    'float8_e4m3fn',
+    'float8_e5m2'
+]
 
 from typing import Type
 
@@ -20,13 +28,13 @@ from ml_dtypes._custom_floats import bfloat16
 from ml_dtypes._custom_floats import float8_e4m3b11
 from ml_dtypes._custom_floats import float8_e4m3fn
 from ml_dtypes._custom_floats import float8_e5m2
+from ml_dtypes._finfo import finfo
+
 import numpy as np
 
 bfloat16: Type[np.generic]
 float8_e4m3b11: Type[np.generic]
 float8_e4m3fn: Type[np.generic]
 float8_e5m2: Type[np.generic]
-
-__all__ = ['bfloat16', 'float8_e4m3b11', 'float8_e4m3fn', 'float8_e5m2']
 
 del np, Type

--- a/ml_dtypes/_finfo.py
+++ b/ml_dtypes/_finfo.py
@@ -1,0 +1,277 @@
+# Copyright 2023 The ml_dtypes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Overload of numpy.finfo to handle dtypes defined in ml_dtypes."""
+
+from typing import Dict
+
+from ml_dtypes._custom_floats import bfloat16
+from ml_dtypes._custom_floats import float8_e4m3b11
+from ml_dtypes._custom_floats import float8_e4m3fn
+from ml_dtypes._custom_floats import float8_e5m2
+
+import numpy as np
+
+_bfloat16_dtype = np.dtype(bfloat16)
+_float8_e4m3b11_dtype = np.dtype(float8_e4m3b11)
+_float8_e4m3fn_dtype = np.dtype(float8_e4m3fn)
+_float8_e5m2_dtype = np.dtype(float8_e5m2)
+
+
+class _Bfloat16MachArLike:
+
+  def __init__(self):
+    smallest_normal = float.fromhex("0x1p-126")
+    self.smallest_normal = bfloat16(smallest_normal)
+    smallest_subnormal = float.fromhex("0x1p-133")
+    self.smallest_subnormal = bfloat16(smallest_subnormal)
+
+
+class _Float8E4m3B11MachArLike:
+
+  def __init__(self):
+    smallest_normal = float.fromhex("0x1p-10")
+    self.smallest_normal = float8_e4m3b11(smallest_normal)
+    smallest_subnormal = float.fromhex("0x1p-13")
+    self.smallest_subnormal = float8_e4m3b11(smallest_subnormal)
+
+
+class _Float8E4m3FnMachArLike:
+
+  def __init__(self):
+    smallest_normal = float.fromhex("0x1p-6")
+    self.smallest_normal = float8_e4m3fn(smallest_normal)
+    smallest_subnormal = float.fromhex("0x1p-9")
+    self.smallest_subnormal = float8_e4m3fn(smallest_subnormal)
+
+
+class _Float8E5m2MachArLike:
+
+  def __init__(self):
+    smallest_normal = float.fromhex("0x1p-14")
+    self.smallest_normal = float8_e5m2(smallest_normal)
+    smallest_subnormal = float.fromhex("0x1p-16")
+    self.smallest_subnormal = float8_e5m2(smallest_subnormal)
+
+
+class finfo(np.finfo):  # pylint: disable=invalid-name,missing-class-docstring
+  __doc__ = np.finfo.__doc__
+  _finfo_cache: Dict[np.dtype, np.finfo] = {}
+
+  @staticmethod
+  def _bfloat16_finfo():
+    def float_to_str(f):
+      return "%12.4e" % float(f)
+
+    tiny = float.fromhex("0x1p-126")
+    resolution = 0.01
+    eps = float.fromhex("0x1p-7")
+    epsneg = float.fromhex("0x1p-8")
+    max_ = float.fromhex("0x1.FEp127")
+
+    obj = object.__new__(np.finfo)
+    obj.dtype = _bfloat16_dtype
+    obj.bits = 16
+    obj.eps = bfloat16(eps)
+    obj.epsneg = bfloat16(epsneg)
+    obj.machep = -7
+    obj.negep = -8
+    obj.max = bfloat16(max_)
+    obj.min = bfloat16(-max_)
+    obj.nexp = 8
+    obj.nmant = 7
+    obj.iexp = obj.nexp
+    obj.maxexp = 128
+    obj.precision = 2
+    obj.resolution = bfloat16(resolution)
+    # pylint: disable=protected-access
+    obj._machar = _Bfloat16MachArLike()
+    if not hasattr(obj, "tiny"):
+      obj.tiny = bfloat16(tiny)
+    if not hasattr(obj, "smallest_normal"):
+      obj.smallest_normal = obj._machar.smallest_normal
+    obj.smallest_subnormal = obj._machar.smallest_subnormal
+
+    obj._str_tiny = float_to_str(tiny)
+    obj._str_smallest_normal = float_to_str(tiny)
+    obj._str_max = float_to_str(max_)
+    obj._str_epsneg = float_to_str(epsneg)
+    obj._str_eps = float_to_str(eps)
+    obj._str_resolution = float_to_str(resolution)
+    # pylint: enable=protected-access
+    return obj
+
+  @staticmethod
+  def _float8_e4m3b11_finfo():
+    def float_to_str(f):
+      return "%6.2e" % float(f)
+
+    tiny = float.fromhex("0x1p-10")
+    resolution = 0.1
+    eps = float.fromhex("0x1p-3")
+    epsneg = float.fromhex("0x1p-4")
+    max_ = float.fromhex("0x1.Ep4")
+
+    obj = object.__new__(np.finfo)
+    obj.dtype = _float8_e4m3b11_dtype
+    obj.bits = 8
+    obj.eps = float8_e4m3b11(eps)
+    obj.epsneg = float8_e4m3b11(epsneg)
+    obj.machep = -3
+    obj.negep = -4
+    obj.max = float8_e4m3b11(max_)
+    obj.min = float8_e4m3b11(-max_)
+    obj.nexp = 4
+    obj.nmant = 3
+    obj.iexp = obj.nexp
+    obj.maxexp = 5
+    obj.precision = 1
+    obj.resolution = float8_e4m3b11(resolution)
+    # pylint: disable=protected-access
+    obj._machar = _Float8E4m3B11MachArLike()
+    if not hasattr(obj, "tiny"):
+      obj.tiny = float8_e4m3b11(tiny)
+    if not hasattr(obj, "smallest_normal"):
+      obj.smallest_normal = obj._machar.smallest_normal
+    obj.smallest_subnormal = obj._machar.smallest_subnormal
+
+    obj._str_tiny = float_to_str(tiny)
+    obj._str_smallest_normal = float_to_str(tiny)
+    obj._str_max = float_to_str(max_)
+    obj._str_epsneg = float_to_str(epsneg)
+    obj._str_eps = float_to_str(eps)
+    obj._str_resolution = float_to_str(resolution)
+    # pylint: enable=protected-access
+    return obj
+
+  @staticmethod
+  def _float8_e4m3fn_finfo():
+    def float_to_str(f):
+      return "%6.2e" % float(f)
+
+    tiny = float.fromhex("0x1p-6")
+    resolution = 0.1
+    eps = float.fromhex("0x1p-3")
+    epsneg = float.fromhex("0x1p-4")
+    max_ = float.fromhex("0x1.Cp8")
+
+    obj = object.__new__(np.finfo)
+    obj.dtype = _float8_e4m3fn_dtype
+    obj.bits = 8
+    obj.eps = float8_e4m3fn(eps)
+    obj.epsneg = float8_e4m3fn(epsneg)
+    obj.machep = -3
+    obj.negep = -4
+    obj.max = float8_e4m3fn(max_)
+    obj.min = float8_e4m3fn(-max_)
+    obj.nexp = 4
+    obj.nmant = 3
+    obj.iexp = obj.nexp
+    obj.maxexp = 9
+    obj.precision = 1
+    obj.resolution = float8_e4m3fn(resolution)
+    # pylint: disable=protected-access
+    obj._machar = _Float8E4m3FnMachArLike()
+    if not hasattr(obj, "tiny"):
+      obj.tiny = float8_e4m3fn(tiny)
+    if not hasattr(obj, "smallest_normal"):
+      obj.smallest_normal = obj._machar.smallest_normal
+    obj.smallest_subnormal = obj._machar.smallest_subnormal
+
+    obj._str_tiny = float_to_str(tiny)
+    obj._str_smallest_normal = float_to_str(tiny)
+    obj._str_max = float_to_str(max_)
+    obj._str_epsneg = float_to_str(epsneg)
+    obj._str_eps = float_to_str(eps)
+    obj._str_resolution = float_to_str(resolution)
+    # pylint: enable=protected-access
+    return obj
+
+  @staticmethod
+  def _float8_e5m2_finfo():
+    def float_to_str(f):
+      return "%6.2e" % float(f)
+
+    tiny = float.fromhex("0x1p-14")
+    resolution = 0.1
+    eps = float.fromhex("0x1p-2")
+    epsneg = float.fromhex("0x1p-3")
+    max_ = float.fromhex("0x1.Cp15")
+
+    obj = object.__new__(np.finfo)
+    obj.dtype = _float8_e5m2_dtype
+    obj.bits = 8
+    obj.eps = float8_e5m2(eps)
+    obj.epsneg = float8_e5m2(epsneg)
+    obj.machep = -2
+    obj.negep = -3
+    obj.max = float8_e5m2(max_)
+    obj.min = float8_e5m2(-max_)
+    obj.nexp = 5
+    obj.nmant = 2
+    obj.iexp = obj.nexp
+    obj.maxexp = 16
+    obj.precision = 1
+    obj.resolution = float8_e5m2(resolution)
+    # pylint: disable=protected-access
+    obj._machar = _Float8E5m2MachArLike()
+    if not hasattr(obj, "tiny"):
+      obj.tiny = float8_e5m2(tiny)
+    if not hasattr(obj, "smallest_normal"):
+      obj.smallest_normal = obj._machar.smallest_normal
+    obj.smallest_subnormal = obj._machar.smallest_subnormal
+
+    obj._str_tiny = float_to_str(tiny)
+    obj._str_smallest_normal = float_to_str(tiny)
+    obj._str_max = float_to_str(max_)
+    obj._str_epsneg = float_to_str(epsneg)
+    obj._str_eps = float_to_str(eps)
+    obj._str_resolution = float_to_str(resolution)
+    # pylint: enable=protected-access
+    return obj
+
+  def __new__(cls, dtype):
+    if (
+        isinstance(dtype, str)
+        and dtype == "bfloat16"
+        or dtype == _bfloat16_dtype
+    ):
+      if _bfloat16_dtype not in cls._finfo_cache:
+        cls._finfo_cache[_bfloat16_dtype] = cls._bfloat16_finfo()
+      return cls._finfo_cache[_bfloat16_dtype]
+    if (
+        isinstance(dtype, str)
+        and dtype == "float8_e4m3b11"
+        or dtype == _float8_e4m3b11_dtype
+    ):
+      if _float8_e4m3b11_dtype not in cls._finfo_cache:
+        cls._finfo_cache[_float8_e4m3b11_dtype] = cls._float8_e4m3b11_finfo()
+      return cls._finfo_cache[_float8_e4m3b11_dtype]
+    if (
+        isinstance(dtype, str)
+        and dtype == "float8_e4m3fn"
+        or dtype == _float8_e4m3fn_dtype
+    ):
+      if _float8_e4m3fn_dtype not in cls._finfo_cache:
+        cls._finfo_cache[_float8_e4m3fn_dtype] = cls._float8_e4m3fn_finfo()
+      return cls._finfo_cache[_float8_e4m3fn_dtype]
+    if (
+        isinstance(dtype, str)
+        and dtype == "float8_e5m2"
+        or dtype == _float8_e5m2_dtype
+    ):
+      if _float8_e5m2_dtype not in cls._finfo_cache:
+        cls._finfo_cache[_float8_e5m2_dtype] = cls._float8_e5m2_finfo()
+      return cls._finfo_cache[_float8_e5m2_dtype]
+    return super().__new__(cls, dtype)

--- a/ml_dtypes/tests/finfo_test.py
+++ b/ml_dtypes/tests/finfo_test.py
@@ -1,0 +1,79 @@
+# Copyright 2023 The ml_dtypes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import ml_dtypes
+import numpy as np
+
+ALL_DTYPES = [
+    ml_dtypes.bfloat16,
+    ml_dtypes.float8_e4m3b11,
+    ml_dtypes.float8_e4m3fn,
+    ml_dtypes.float8_e5m2,
+]
+
+
+class FinfoTest(parameterized.TestCase):
+
+  def assertNanEqual(self, x, y):
+    if np.isnan(x) and np.isnan(y):
+      return
+    self.assertEqual(x, y)
+
+  @parameterized.named_parameters(
+      {"testcase_name": f"_{dtype.__name__}", "dtype": np.dtype(dtype)}
+      for dtype in ALL_DTYPES
+  )
+  def testFInfo(self, dtype):
+    info = ml_dtypes.finfo(dtype)
+    assert ml_dtypes.finfo(dtype.name) is info
+    assert ml_dtypes.finfo(dtype.type) is info
+
+    def make_val(val):
+      return np.array(val, dtype=dtype)
+
+    def assert_representable(val):
+      self.assertEqual(make_val(val).item(), val)
+
+    def assert_infinite(val):
+      self.assertNanEqual(make_val(val), make_val(np.inf))
+
+    def assert_zero(val):
+      self.assertEqual(make_val(val), make_val(0))
+
+    self.assertEqual(np.array(0, dtype).dtype, dtype)
+    self.assertIs(info.dtype, dtype)
+
+    self.assertEqual(info.bits, np.array(0, dtype).itemsize * 8)
+    self.assertEqual(info.nmant + info.nexp + 1, info.bits)
+
+    assert_representable(info.tiny)
+    assert_representable(info.max)
+    assert_representable(2.0 ** (info.maxexp - 1))
+    assert_infinite(2.0**info.maxexp)
+
+    assert_representable(info.smallest_subnormal)
+    assert_zero(info.smallest_subnormal * 0.5)
+    self.assertEqual(info.tiny, info.smallest_normal)
+
+    # Identities according to the documentation:
+    np.testing.assert_allclose(info.resolution, make_val(10**-info.precision))
+    self.assertEqual(info.epsneg, make_val(2**info.negep))
+    self.assertEqual(info.eps, make_val(2**info.machep))
+    self.assertEqual(info.iexp, info.nexp)
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
This adds `ml_dtypes.finfo`, an extension of `np.finfo` that works for the dtypes defined in this package.

For example:
```python
In [1]: import ml_dtypes

In [2]: ml_dtypes.finfo('bfloat16').max
Out[2]: 3.38953e+38

In [3]: ml_dtypes.finfo('float8_e5m2').max
Out[3]: 57344
```