### PR TITLE
Add py.typed file to distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,3 +58,6 @@ packages = ["ml_dtypes", "ml_dtypes._src"]
 
 [tool.setuptools.packages]
 find = {}
+
+[tool.setuptools.package-data]
+ml_dtypes = ["py.typed"]


### PR DESCRIPTION
Fixes #43

Confirmed it makes it into the distributions:
```
$ python -m build
<...>

$ unzip -l dist/ml_dtypes-0.0.3-cp38-cp38-macosx_10_9_x86_64.whl | grep "py.typed"
        0  03-24-2023 23:24   ml_dtypes/py.typed

$ tar -ztvf dist/ml_dtypes-0.0.3.tar.gz | grep "py.typed"
-rw-r--r--  0 vanderplas primarygroup     0 Mar 24 16:24 ml_dtypes-0.0.3/ml_dtypes/py.typed
```