### PR TITLE
Build aarch64 wheels using qemu.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -33,12 +33,19 @@ jobs:
         with:
           python-version: "3.9"
 
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.12.1
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
+          CIBW_ARCHS_LINUX: auto aarch64
           CIBW_ARCHS_MACOS: universal2
           CIBW_BUILD: cp38-* cp39-* cp310-* cp311-*
           CIBW_SKIP: "*musllinux* *i686* *win32*"


### PR DESCRIPTION
See https://cibuildwheel.readthedocs.io/en/stable/faq/#emulation

Fixes https://github.com/jax-ml/ml_dtypes/issues/45