### PR TITLE
Add float8_e4m3fnuz and float8_e5m2fnuz

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@
   including:
   * `float8_e4m3b11`
   * `float8_e4m3fn`
+  * `float8_e4m3fnuz`
   * `float8_e5m2`
+  * `float8_e5m2fnuz`
 
 ## Installation
 

--- a/ml_dtypes/__init__.py
+++ b/ml_dtypes/__init__.py
@@ -19,7 +19,9 @@ __all__ = [
     'finfo',
     'float8_e4m3b11',
     'float8_e4m3fn',
+    'float8_e4m3fnuz',
     'float8_e5m2',
+    'float8_e5m2fnuz',
 ]
 
 from typing import Type
@@ -27,7 +29,9 @@ from typing import Type
 from ml_dtypes._custom_floats import bfloat16
 from ml_dtypes._custom_floats import float8_e4m3b11
 from ml_dtypes._custom_floats import float8_e4m3fn
+from ml_dtypes._custom_floats import float8_e4m3fnuz
 from ml_dtypes._custom_floats import float8_e5m2
+from ml_dtypes._custom_floats import float8_e5m2fnuz
 from ml_dtypes._finfo import finfo
 
 import numpy as np
@@ -35,6 +39,8 @@ import numpy as np
 bfloat16: Type[np.generic]
 float8_e4m3b11: Type[np.generic]
 float8_e4m3fn: Type[np.generic]
+float8_e4m3fnuz: Type[np.generic]
 float8_e5m2: Type[np.generic]
+float8_e5m2fnuz: Type[np.generic]
 
 del np, Type

--- a/ml_dtypes/_finfo.py
+++ b/ml_dtypes/_finfo.py
@@ -19,14 +19,18 @@ from typing import Dict
 from ml_dtypes._custom_floats import bfloat16
 from ml_dtypes._custom_floats import float8_e4m3b11
 from ml_dtypes._custom_floats import float8_e4m3fn
+from ml_dtypes._custom_floats import float8_e4m3fnuz
 from ml_dtypes._custom_floats import float8_e5m2
+from ml_dtypes._custom_floats import float8_e5m2fnuz
 
 import numpy as np
 
 _bfloat16_dtype = np.dtype(bfloat16)
 _float8_e4m3b11_dtype = np.dtype(float8_e4m3b11)
 _float8_e4m3fn_dtype = np.dtype(float8_e4m3fn)
+_float8_e4m3fnuz_dtype = np.dtype(float8_e4m3fnuz)
 _float8_e5m2_dtype = np.dtype(float8_e5m2)
+_float8_e5m2fnuz_dtype = np.dtype(float8_e5m2fnuz)
 
 
 class _Bfloat16MachArLike:
@@ -56,6 +60,15 @@ class _Float8E4m3FnMachArLike:
     self.smallest_subnormal = float8_e4m3fn(smallest_subnormal)
 
 
+class _Float8E4m3FnuzMachArLike:
+
+  def __init__(self):
+    smallest_normal = float.fromhex("0x1p-7")
+    self.smallest_normal = float8_e4m3fnuz(smallest_normal)
+    smallest_subnormal = float.fromhex("0x1p-10")
+    self.smallest_subnormal = float8_e4m3fnuz(smallest_subnormal)
+
+
 class _Float8E5m2MachArLike:
 
   def __init__(self):
@@ -63,6 +76,15 @@ class _Float8E5m2MachArLike:
     self.smallest_normal = float8_e5m2(smallest_normal)
     smallest_subnormal = float.fromhex("0x1p-16")
     self.smallest_subnormal = float8_e5m2(smallest_subnormal)
+
+
+class _Float8E5m2FnuzMachArLike:
+
+  def __init__(self):
+    smallest_normal = float.fromhex("0x1p-15")
+    self.smallest_normal = float8_e5m2fnuz(smallest_normal)
+    smallest_subnormal = float.fromhex("0x1p-17")
+    self.smallest_subnormal = float8_e5m2fnuz(smallest_subnormal)
 
 
 class finfo(np.finfo):  # pylint: disable=invalid-name,missing-class-docstring
@@ -205,6 +227,51 @@ class finfo(np.finfo):  # pylint: disable=invalid-name,missing-class-docstring
     return obj
 
   @staticmethod
+  def _float8_e4m3fnuz_finfo():
+    def float_to_str(f):
+      return "%6.2e" % float(f)
+
+    tiny = float.fromhex("0x1p-7")
+    resolution = 0.1
+    eps = float.fromhex("0x1p-3")
+    epsneg = float.fromhex("0x1p-4")
+    max_ = float.fromhex("0x1.Ep7")
+
+    obj = object.__new__(np.finfo)
+    obj.dtype = _float8_e4m3fnuz_dtype
+    obj.bits = 8
+    obj.eps = float8_e4m3fnuz(eps)
+    obj.epsneg = float8_e4m3fnuz(epsneg)
+    obj.machep = -3
+    obj.negep = -4
+    obj.max = float8_e4m3fnuz(max_)
+    obj.min = float8_e4m3fnuz(-max_)
+    obj.nexp = 4
+    obj.nmant = 3
+    obj.iexp = obj.nexp
+    obj.maxexp = 8
+    obj.minexp = -7
+    obj.precision = 1
+    obj.resolution = float8_e4m3fnuz(resolution)
+    # pylint: disable=protected-access
+    obj._machar = _Float8E4m3FnuzMachArLike()
+    if not hasattr(obj, "tiny"):
+      obj.tiny = float8_e4m3fnuz(tiny)
+    if not hasattr(obj, "smallest_normal"):
+      obj.smallest_normal = obj._machar.smallest_normal
+    obj.smallest_subnormal = obj._machar.smallest_subnormal
+
+    obj._str_tiny = float_to_str(tiny)
+    obj._str_smallest_normal = float_to_str(tiny)
+    obj._str_smallest_subnormal = float_to_str(obj.smallest_subnormal)
+    obj._str_max = float_to_str(max_)
+    obj._str_epsneg = float_to_str(epsneg)
+    obj._str_eps = float_to_str(eps)
+    obj._str_resolution = float_to_str(resolution)
+    # pylint: enable=protected-access
+    return obj
+
+  @staticmethod
   def _float8_e5m2_finfo():
     def float_to_str(f):
       return "%6.2e" % float(f)
@@ -249,6 +316,51 @@ class finfo(np.finfo):  # pylint: disable=invalid-name,missing-class-docstring
     # pylint: enable=protected-access
     return obj
 
+  @staticmethod
+  def _float8_e5m2fnuz_finfo():
+    def float_to_str(f):
+      return "%6.2e" % float(f)
+
+    tiny = float.fromhex("0x1p-15")
+    resolution = 0.1
+    eps = float.fromhex("0x1p-2")
+    epsneg = float.fromhex("0x1p-3")
+    max_ = float.fromhex("0x1.Cp15")
+
+    obj = object.__new__(np.finfo)
+    obj.dtype = _float8_e5m2fnuz_dtype
+    obj.bits = 8
+    obj.eps = float8_e5m2fnuz(eps)
+    obj.epsneg = float8_e5m2fnuz(epsneg)
+    obj.machep = -2
+    obj.negep = -3
+    obj.max = float8_e5m2fnuz(max_)
+    obj.min = float8_e5m2fnuz(-max_)
+    obj.nexp = 5
+    obj.nmant = 2
+    obj.iexp = obj.nexp
+    obj.maxexp = 16
+    obj.minexp = -15
+    obj.precision = 1
+    obj.resolution = float8_e5m2fnuz(resolution)
+    # pylint: disable=protected-access
+    obj._machar = _Float8E5m2FnuzMachArLike()
+    if not hasattr(obj, "tiny"):
+      obj.tiny = float8_e5m2fnuz(tiny)
+    if not hasattr(obj, "smallest_normal"):
+      obj.smallest_normal = obj._machar.smallest_normal
+    obj.smallest_subnormal = obj._machar.smallest_subnormal
+
+    obj._str_tiny = float_to_str(tiny)
+    obj._str_smallest_normal = float_to_str(tiny)
+    obj._str_smallest_subnormal = float_to_str(obj.smallest_subnormal)
+    obj._str_max = float_to_str(max_)
+    obj._str_epsneg = float_to_str(epsneg)
+    obj._str_eps = float_to_str(eps)
+    obj._str_resolution = float_to_str(resolution)
+    # pylint: enable=protected-access
+    return obj
+
   def __new__(cls, dtype):
     if (
         isinstance(dtype, str)
@@ -276,10 +388,26 @@ class finfo(np.finfo):  # pylint: disable=invalid-name,missing-class-docstring
       return cls._finfo_cache[_float8_e4m3fn_dtype]
     if (
         isinstance(dtype, str)
+        and dtype == "float8_e4m3fnuz"
+        or dtype == _float8_e4m3fnuz_dtype
+    ):
+      if _float8_e4m3fnuz_dtype not in cls._finfo_cache:
+        cls._finfo_cache[_float8_e4m3fnuz_dtype] = cls._float8_e4m3fnuz_finfo()
+      return cls._finfo_cache[_float8_e4m3fnuz_dtype]
+    if (
+        isinstance(dtype, str)
         and dtype == "float8_e5m2"
         or dtype == _float8_e5m2_dtype
     ):
       if _float8_e5m2_dtype not in cls._finfo_cache:
         cls._finfo_cache[_float8_e5m2_dtype] = cls._float8_e5m2_finfo()
       return cls._finfo_cache[_float8_e5m2_dtype]
+    if (
+        isinstance(dtype, str)
+        and dtype == "float8_e5m2fnuz"
+        or dtype == _float8_e5m2fnuz_dtype
+    ):
+      if _float8_e5m2fnuz_dtype not in cls._finfo_cache:
+        cls._finfo_cache[_float8_e5m2fnuz_dtype] = cls._float8_e5m2fnuz_finfo()
+      return cls._finfo_cache[_float8_e5m2fnuz_dtype]
     return super().__new__(cls, dtype)

--- a/ml_dtypes/_src/dtypes.cc
+++ b/ml_dtypes/_src/dtypes.cc
@@ -93,6 +93,20 @@ struct TypeDescriptor<float8_e4m3fn>
 };
 
 template <>
+struct TypeDescriptor<float8_e4m3fnuz>
+    : CustomFloatTypeDescriptor<float8_e4m3fnuz> {
+  typedef float8_e4m3fnuz T;
+  static constexpr const char* kTypeName = "float8_e4m3fnuz";
+  static constexpr const char* kQualifiedTypeName = "ml_dtypes.float8_e4m3fnuz";
+  static constexpr const char* kTpDoc = "float8_e4m3fnuz floating-point values";
+  static constexpr char kNpyDescrKind = 'V';
+  // TODO(phawkins): there doesn't seem to be a way of guaranteeing a type
+  // character is unique.
+  static constexpr char kNpyDescrType = 'G';
+  static constexpr char kNpyDescrByteorder = '=';
+};
+
+template <>
 struct TypeDescriptor<float8_e5m2> : CustomFloatTypeDescriptor<float8_e5m2> {
   typedef float8_e5m2 T;
   static constexpr const char* kTypeName = "float8_e5m2";
@@ -103,6 +117,19 @@ struct TypeDescriptor<float8_e5m2> : CustomFloatTypeDescriptor<float8_e5m2> {
   // TODO(phawkins): there doesn't seem to be a way of guaranteeing a type
   // character is unique.
   static constexpr char kNpyDescrType = '5';
+  static constexpr char kNpyDescrByteorder = '=';
+};
+
+template <>
+struct TypeDescriptor<float8_e5m2fnuz> : CustomFloatTypeDescriptor<float8_e5m2fnuz> {
+  typedef float8_e5m2fnuz T;
+  static constexpr const char* kTypeName = "float8_e5m2fnuz";
+  static constexpr const char* kQualifiedTypeName = "ml_dtypes.float8_e5m2fnuz";
+  static constexpr const char* kTpDoc = "float8_e5m2fnuz floating-point values";
+  static constexpr char kNpyDescrKind = 'V';
+  // TODO(phawkins): there doesn't seem to be a way of guaranteeing a type
+  // character is unique.
+  static constexpr char kNpyDescrType = 'C';
   static constexpr char kNpyDescrByteorder = '=';
 };
 
@@ -165,9 +192,19 @@ bool Initialize() {
           numpy.get(), &float8_e4m3fn_already_registered)) {
     return false;
   }
+  bool float8_e4m3fnuz_already_registered;
+  if (!ml_dtypes::RegisterNumpyDtype<float8_e4m3fnuz>(
+          numpy.get(), &float8_e4m3fnuz_already_registered)) {
+    return false;
+  }
   bool float8_e5m2_already_registered;
   if (!ml_dtypes::RegisterNumpyDtype<float8_e5m2>(
           numpy.get(), &float8_e5m2_already_registered)) {
+    return false;
+  }
+  bool float8_e5m2fnuz_already_registered;
+  if (!ml_dtypes::RegisterNumpyDtype<float8_e5m2fnuz>(
+          numpy.get(), &float8_e5m2fnuz_already_registered)) {
     return false;
   }
 
@@ -178,6 +215,11 @@ bool Initialize() {
   // uninitialized type descriptor in this library.
   if (!float8_e4m3b11_already_registered &&
       !RegisterCustomFloatCast<float8_e4m3b11, bfloat16>()) {
+    return false;
+  }
+  if (!float8_e4m3fnuz_already_registered &&
+      !float8_e5m2fnuz_already_registered &&
+      !RegisterTwoWayCustomCast<float8_e4m3fnuz, float8_e5m2fnuz>()) {
     return false;
   }
   if (!float8_e4m3fn_already_registered && !float8_e5m2_already_registered &&
@@ -191,6 +233,14 @@ bool Initialize() {
   success &= RegisterTwoWayCustomCast<float8_e4m3b11, float8_e5m2>();
   success &= RegisterTwoWayCustomCast<bfloat16, float8_e4m3fn>();
   success &= RegisterTwoWayCustomCast<bfloat16, float8_e5m2>();
+  success &= RegisterTwoWayCustomCast<float8_e4m3fnuz, bfloat16>();
+  success &= RegisterTwoWayCustomCast<float8_e5m2fnuz, bfloat16>();
+  success &= RegisterTwoWayCustomCast<float8_e4m3fnuz, float8_e4m3b11>();
+  success &= RegisterTwoWayCustomCast<float8_e5m2fnuz, float8_e4m3b11>();
+  success &= RegisterTwoWayCustomCast<float8_e4m3fnuz, float8_e4m3fn>();
+  success &= RegisterTwoWayCustomCast<float8_e5m2fnuz, float8_e4m3fn>();
+  success &= RegisterTwoWayCustomCast<float8_e4m3fnuz, float8_e5m2>();
+  success &= RegisterTwoWayCustomCast<float8_e5m2fnuz, float8_e5m2>();
   return success;
 }
 
@@ -231,9 +281,21 @@ extern "C" EXPORT_SYMBOL PyObject* PyInit__custom_floats() {
       0) {
     return nullptr;
   }
+  if (PyObject_SetAttrString(m.get(), "float8_e4m3fnuz",
+                             reinterpret_cast<PyObject *>(
+                                 TypeDescriptor<float8_e4m3fnuz>::type_ptr)) <
+      0) {
+    return nullptr;
+  }
   if (PyObject_SetAttrString(m.get(), "float8_e5m2",
                              reinterpret_cast<PyObject*>(
                                  TypeDescriptor<float8_e5m2>::type_ptr)) < 0) {
+    return nullptr;
+  }
+  if (PyObject_SetAttrString(m.get(), "float8_e5m2fnuz",
+                             reinterpret_cast<PyObject *>(
+                                 TypeDescriptor<float8_e5m2fnuz>::type_ptr)) <
+      0) {
     return nullptr;
   }
   if (PyObject_SetAttrString(m.get(), "bfloat16",

--- a/ml_dtypes/_src/float8.h
+++ b/ml_dtypes/_src/float8.h
@@ -33,8 +33,10 @@ namespace float8_internal {
 
 // Forward-declarations of classes.
 class float8_e4m3fn;
+class float8_e4m3fnuz;
 class float8_e4m3b11;
 class float8_e5m2;
+class float8_e5m2fnuz;
 
 template <typename Derived>
 class float8_base {
@@ -183,7 +185,11 @@ class float8_e4m3fn : public float8_base<float8_e4m3fn> {
       : float8_e4m3fn(ConvertFrom(f16)) {}
   explicit EIGEN_DEVICE_FUNC float8_e4m3fn(const float8_e5m2& f8)
       : float8_e4m3fn(ConvertFrom(f8)) {}
+  explicit EIGEN_DEVICE_FUNC float8_e4m3fn(const float8_e5m2fnuz& f8)
+      : float8_e4m3fn(ConvertFrom(f8)) {}
   explicit EIGEN_DEVICE_FUNC float8_e4m3fn(const float8_e4m3b11& f8)
+      : float8_e4m3fn(ConvertFrom(f8)) {}
+  explicit EIGEN_DEVICE_FUNC float8_e4m3fn(const float8_e4m3fnuz& f8)
       : float8_e4m3fn(ConvertFrom(f8)) {}
 
   template <typename T,
@@ -235,7 +241,11 @@ class float8_e4m3b11 : public float8_base<float8_e4m3b11> {
       : float8_e4m3b11(ConvertFrom(f16)) {}
   explicit EIGEN_DEVICE_FUNC float8_e4m3b11(const float8_e5m2& f8)
       : float8_e4m3b11(ConvertFrom(f8)) {}
+  explicit EIGEN_DEVICE_FUNC float8_e4m3b11(const float8_e5m2fnuz& f8)
+      : float8_e4m3b11(ConvertFrom(f8)) {}
   explicit EIGEN_DEVICE_FUNC float8_e4m3b11(const float8_e4m3fn& f8)
+      : float8_e4m3b11(ConvertFrom(f8)) {}
+  explicit EIGEN_DEVICE_FUNC float8_e4m3b11(const float8_e4m3fnuz& f8)
       : float8_e4m3b11(ConvertFrom(f8)) {}
 
   constexpr float8_e4m3b11 operator-() const {
@@ -246,6 +256,84 @@ class float8_e4m3b11 : public float8_base<float8_e4m3b11> {
   }
 
   float8_e4m3b11 operator-(const float8_e4m3b11& other) const {
+    return Base::operator-(other);
+  }
+
+  template <typename T,
+            typename EnableIf = std::enable_if<std::is_arithmetic_v<T>>>
+  explicit EIGEN_DEVICE_FUNC operator T() const {
+    return static_cast<T>(static_cast<float>(*this));
+  }
+  explicit EIGEN_DEVICE_FUNC operator double() const {
+    return ConvertTo<double>(*this);
+  }
+  explicit EIGEN_DEVICE_FUNC operator float() const {
+    return ConvertTo<float>(*this);
+  }
+  explicit EIGEN_DEVICE_FUNC operator Eigen::bfloat16() const {
+    return ConvertTo<Eigen::bfloat16>(*this);
+  }
+  explicit EIGEN_DEVICE_FUNC operator Eigen::half() const {
+    return ConvertTo<Eigen::half>(*this);
+  }
+  explicit EIGEN_DEVICE_FUNC operator bool() const { return rep() != 0; }
+};
+
+class float8_e4m3fnuz : public float8_base<float8_e4m3fnuz> {
+  // 8-bit floating point with 3 bit mantissa.
+  //
+  // An 8-bit floating point type with 1 sign bit, 4 bits exponent and 3 bits
+  // mantissa. The suffix "fnuz" is consistent with LLVM/MLIR naming and is
+  // derived from the differences to IEEE floating point conventions. `F` is
+  // for "finite" (no infinities), `N` for with special NaN encoding, `UZ` for
+  // unsigned zero.
+  //
+  // This type has the following characteristics:
+  // * bit encoding: S1E4M3 - `0bSEEEEMMM`
+  // * exponent bias: 8
+  // * infinities: Not supported
+  // * NaNs: Supported with sign bit set to 1, exponent bits and mantissa bits
+  // set to all 0s - `0b10000000`
+  // * denormals when exponent is 0
+ private:
+  using Base = float8_base<float8_e4m3fnuz>;
+  friend class float8_base<float8_e4m3fnuz>;
+
+  constexpr float8_e4m3fnuz(uint8_t rep, ConstructFromRepTag)
+      : Base(rep, ConstructFromRepTag{}) {}
+
+ public:
+  constexpr float8_e4m3fnuz() = default;
+
+  template <typename T,
+            typename EnableIf = std::enable_if<std::is_arithmetic_v<T>>>
+  explicit EIGEN_DEVICE_FUNC float8_e4m3fnuz(T f)
+      : float8_e4m3fnuz(ConvertFrom(static_cast<float>(f))) {}
+  explicit EIGEN_DEVICE_FUNC float8_e4m3fnuz(double f64)
+      : float8_e4m3fnuz(ConvertFrom(f64)) {}
+  explicit EIGEN_DEVICE_FUNC float8_e4m3fnuz(float f32)
+      : float8_e4m3fnuz(ConvertFrom(f32)) {}
+  explicit EIGEN_DEVICE_FUNC float8_e4m3fnuz(Eigen::bfloat16 bf16)
+      : float8_e4m3fnuz(ConvertFrom(bf16)) {}
+  explicit EIGEN_DEVICE_FUNC float8_e4m3fnuz(Eigen::half f16)
+      : float8_e4m3fnuz(ConvertFrom(f16)) {}
+  explicit EIGEN_DEVICE_FUNC float8_e4m3fnuz(const float8_e5m2& f8)
+      : float8_e4m3fnuz(ConvertFrom(f8)) {}
+  explicit EIGEN_DEVICE_FUNC float8_e4m3fnuz(const float8_e5m2fnuz& f8)
+      : float8_e4m3fnuz(ConvertFrom(f8)) {}
+  explicit EIGEN_DEVICE_FUNC float8_e4m3fnuz(const float8_e4m3b11& f8)
+      : float8_e4m3fnuz(ConvertFrom(f8)) {}
+  explicit EIGEN_DEVICE_FUNC float8_e4m3fnuz(const float8_e4m3fn& f8)
+      : float8_e4m3fnuz(ConvertFrom(f8)) {}
+
+  constexpr float8_e4m3fnuz operator-() const {
+    if ((rep() & 0x7f) == 0x00) {
+      return float8_e4m3fnuz(rep(), ConstructFromRepTag{});
+    }
+    return Base::operator-();
+  }
+
+  float8_e4m3fnuz operator-(const float8_e4m3fnuz& other) const {
     return Base::operator-(other);
   }
 
@@ -296,7 +384,11 @@ class float8_e5m2 : public float8_base<float8_e5m2> {
       : float8_e5m2(ConvertFrom(f16)) {}
   explicit EIGEN_DEVICE_FUNC float8_e5m2(float8_e4m3fn f8)
       : float8_e5m2(ConvertFrom(f8)) {}
+  explicit EIGEN_DEVICE_FUNC float8_e5m2(float8_e4m3fnuz f8)
+      : float8_e5m2(ConvertFrom(f8)) {}
   explicit EIGEN_DEVICE_FUNC float8_e5m2(float8_e4m3b11 f8)
+      : float8_e5m2(ConvertFrom(f8)) {}
+  explicit EIGEN_DEVICE_FUNC float8_e5m2(float8_e5m2fnuz& f8)
       : float8_e5m2(ConvertFrom(f8)) {}
 
   template <typename T,
@@ -319,6 +411,84 @@ class float8_e5m2 : public float8_base<float8_e5m2> {
   explicit EIGEN_DEVICE_FUNC operator bool() const {
     return (rep() & 0x7F) != 0;
   }
+};
+
+class float8_e5m2fnuz : public float8_base<float8_e5m2fnuz> {
+  // 8-bit floating point with 2 bit mantissa.
+  //
+  // An 8-bit floating point type with 1 sign bit, 5 bits exponent and 2 bits
+  // mantissa. The suffix "fnuz" is consistent with LLVM/MLIR naming and is
+  // derived from the differences to IEEE floating point conventions. `F` is
+  // for "finite" (no infinities), `N` for with special NaN encoding, `UZ` for
+  // unsigned zero.
+  //
+  // This type has the following characteristics:
+  // * bit encoding: S1E5M2 - `0bSEEEEEMM`
+  // * exponent bias: 16
+  // * infinities: Not supported
+  // * NaNs: Supported with sign bit set to 1, exponent bits and mantissa bits
+  // set to all 0s - `0b10000000`
+  // * denormals when exponent is 0
+ private:
+  using Base = float8_base<float8_e5m2fnuz>;
+  friend class float8_base<float8_e5m2fnuz>;
+
+  constexpr float8_e5m2fnuz(uint8_t rep, ConstructFromRepTag)
+      : Base(rep, ConstructFromRepTag{}) {}
+
+ public:
+  constexpr float8_e5m2fnuz() = default;
+
+  template <typename T,
+            typename EnableIf = std::enable_if<std::is_arithmetic_v<T>>>
+  explicit EIGEN_DEVICE_FUNC float8_e5m2fnuz(T f)
+      : float8_e5m2fnuz(ConvertFrom(static_cast<float>(f))) {}
+  explicit EIGEN_DEVICE_FUNC float8_e5m2fnuz(double f64)
+      : float8_e5m2fnuz(ConvertFrom(f64)) {}
+  explicit EIGEN_DEVICE_FUNC float8_e5m2fnuz(float f32)
+      : float8_e5m2fnuz(ConvertFrom(f32)) {}
+  explicit EIGEN_DEVICE_FUNC float8_e5m2fnuz(Eigen::bfloat16 bf16)
+      : float8_e5m2fnuz(ConvertFrom(bf16)) {}
+  explicit EIGEN_DEVICE_FUNC float8_e5m2fnuz(Eigen::half f16)
+      : float8_e5m2fnuz(ConvertFrom(f16)) {}
+  explicit EIGEN_DEVICE_FUNC float8_e5m2fnuz(const float8_e5m2& f8)
+      : float8_e5m2fnuz(ConvertFrom(f8)) {}
+  explicit EIGEN_DEVICE_FUNC float8_e5m2fnuz(const float8_e4m3b11& f8)
+      : float8_e5m2fnuz(ConvertFrom(f8)) {}
+  explicit EIGEN_DEVICE_FUNC float8_e5m2fnuz(const float8_e4m3fn& f8)
+      : float8_e5m2fnuz(ConvertFrom(f8)) {}
+  explicit EIGEN_DEVICE_FUNC float8_e5m2fnuz(const float8_e4m3fnuz& f8)
+      : float8_e5m2fnuz(ConvertFrom(f8)) {}
+
+  constexpr float8_e5m2fnuz operator-() const {
+    if ((rep() & 0x7f) == 0x00) {
+      return float8_e5m2fnuz(rep(), ConstructFromRepTag{});
+    }
+    return Base::operator-();
+  }
+
+  float8_e5m2fnuz operator-(const float8_e5m2fnuz& other) const {
+    return Base::operator-(other);
+  }
+
+  template <typename T,
+            typename EnableIf = std::enable_if<std::is_arithmetic_v<T>>>
+  explicit EIGEN_DEVICE_FUNC operator T() const {
+    return static_cast<T>(static_cast<float>(*this));
+  }
+  explicit EIGEN_DEVICE_FUNC operator double() const {
+    return ConvertTo<double>(*this);
+  }
+  explicit EIGEN_DEVICE_FUNC operator float() const {
+    return ConvertTo<float>(*this);
+  }
+  explicit EIGEN_DEVICE_FUNC operator Eigen::bfloat16() const {
+    return ConvertTo<Eigen::bfloat16>(*this);
+  }
+  explicit EIGEN_DEVICE_FUNC operator Eigen::half() const {
+    return ConvertTo<Eigen::half>(*this);
+  }
+  explicit EIGEN_DEVICE_FUNC operator bool() const { return rep() != 0; }
 };
 
 // Structures for use in specializing std::numeric_limits.
@@ -452,6 +622,56 @@ struct numeric_limits_float8<float8_e4m3b11>
 };
 
 template <>
+struct numeric_limits_float8<float8_e4m3fnuz>
+    : public numeric_limits_float8_base {
+  // NOLINTBEGIN: these names must match std::numeric_limits.
+  static inline constexpr const int digits = 4;
+  static inline constexpr const int digits10 = 0;      // floor(3 * log10(2));
+  static inline constexpr const int max_digits10 = 3;  // ceil(4 * log10(2) + 1)
+  static inline constexpr const int min_exponent = -6;
+  static inline constexpr const int min_exponent10 = -2;
+  static inline constexpr const int max_exponent = 7;
+  static inline constexpr const int max_exponent10 = 2;
+  static inline constexpr const bool is_iec559 = false;
+  static inline constexpr const bool has_infinity = false;
+  static inline constexpr const bool has_signaling_NaN = false;
+  // NOLINTEND
+
+  static constexpr float8_e4m3fnuz min() {
+    return float8_e4m3fnuz::FromRep(0x08);
+  }
+  static constexpr float8_e4m3fnuz lowest() {
+    return float8_e4m3fnuz::FromRep(0xFF);
+  }
+  static constexpr float8_e4m3fnuz max() {
+    return float8_e4m3fnuz::FromRep(0x7F);
+  }
+  static constexpr float8_e4m3fnuz epsilon() {
+    constexpr int kExponentBias = 8;
+    constexpr int kMantissaBits = 3;
+    return float8_e4m3fnuz::FromRep((kExponentBias - kMantissaBits)
+                                   << kMantissaBits);
+  }
+  static constexpr float8_e4m3fnuz round_error() {
+    constexpr int kExponentBias = 8;
+    constexpr int kMantissaBits = 3;
+    return float8_e4m3fnuz::FromRep((kExponentBias - 1) << kMantissaBits);
+  }
+  static constexpr float8_e4m3fnuz infinity() {
+    return float8_e4m3fnuz::FromRep(0x80);
+  }  // NaN.
+  static constexpr float8_e4m3fnuz quiet_NaN() {
+    return float8_e4m3fnuz::FromRep(0x80);
+  }
+  static constexpr float8_e4m3fnuz signaling_NaN() {
+    return float8_e4m3fnuz::FromRep(0x80);
+  }
+  static constexpr float8_e4m3fnuz denorm_min() {
+    return float8_e4m3fnuz::FromRep(0x01);
+  }
+};
+
+template <>
 struct numeric_limits_float8<float8_e5m2> : public numeric_limits_float8_base {
   // NOLINTBEGIN: these names must match std::numeric_limits.
   static inline constexpr const int digits = 3;
@@ -485,6 +705,56 @@ struct numeric_limits_float8<float8_e5m2> : public numeric_limits_float8_base {
   }
 };
 
+template <>
+struct numeric_limits_float8<float8_e5m2fnuz>
+    : public numeric_limits_float8_base {
+  // NOLINTBEGIN: these names must match std::numeric_limits.
+  static inline constexpr const int digits = 3;
+  static inline constexpr const int digits10 = 0;      // floor(2 * log10(2))
+  static inline constexpr const int max_digits10 = 2;  // ceil(3 * log10(2) + 1)
+  static inline constexpr const int min_exponent = -14;
+  static inline constexpr const int min_exponent10 = -4;
+  static inline constexpr const int max_exponent = 16;
+  static inline constexpr const int max_exponent10 = 4;
+  static inline constexpr const bool is_iec559 = false;
+  static inline constexpr const bool has_infinity = false;
+  static inline constexpr const bool has_signaling_NaN = false;
+  // NOLINTEND
+
+  static constexpr float8_e5m2fnuz min() {
+    return float8_e5m2fnuz::FromRep(0x08);
+  }
+  static constexpr float8_e5m2fnuz lowest() {
+    return float8_e5m2fnuz::FromRep(0xFF);
+  }
+  static constexpr float8_e5m2fnuz max() {
+    return float8_e5m2fnuz::FromRep(0x7F);
+  }
+  static constexpr float8_e5m2fnuz epsilon() {
+    constexpr int kExponentBias = 16;
+    constexpr int kMantissaBits = 2;
+    return float8_e5m2fnuz::FromRep((kExponentBias - kMantissaBits)
+                                   << kMantissaBits);
+  }
+  static constexpr float8_e5m2fnuz round_error() {
+    constexpr int kExponentBias = 16;
+    constexpr int kMantissaBits = 2;
+    return float8_e5m2fnuz::FromRep((kExponentBias - 1) << kMantissaBits);
+  }
+  static constexpr float8_e5m2fnuz infinity() {
+    return float8_e5m2fnuz::FromRep(0x80);
+  }  // NaN.
+  static constexpr float8_e5m2fnuz quiet_NaN() {
+    return float8_e5m2fnuz::FromRep(0x80);
+  }
+  static constexpr float8_e5m2fnuz signaling_NaN() {
+    return float8_e5m2fnuz::FromRep(0x80);
+  }
+  static constexpr float8_e5m2fnuz denorm_min() {
+    return float8_e5m2fnuz::FromRep(0x01);
+  }
+};
+
 }  // namespace float8_internal
 }  // namespace ml_dtypes
 
@@ -501,9 +771,19 @@ struct numeric_limits<ml_dtypes::float8_internal::float8_e4m3b11>
           ml_dtypes::float8_internal::float8_e4m3b11> {};
 
 template <>
+struct numeric_limits<ml_dtypes::float8_internal::float8_e4m3fnuz>
+    : public ml_dtypes::float8_internal::numeric_limits_float8<
+          ml_dtypes::float8_internal::float8_e4m3fnuz> {};
+
+template <>
 struct numeric_limits<ml_dtypes::float8_internal::float8_e5m2>
     : public ml_dtypes::float8_internal::numeric_limits_float8<
           ml_dtypes::float8_internal::float8_e5m2> {};
+
+template <>
+struct numeric_limits<ml_dtypes::float8_internal::float8_e5m2fnuz>
+    : public ml_dtypes::float8_internal::numeric_limits_float8<
+          ml_dtypes::float8_internal::float8_e5m2fnuz> {};
 }  // namespace std
 
 namespace ml_dtypes {
@@ -541,6 +821,21 @@ constexpr inline bool isfinite(const float8_e4m3b11& a) {
   return !isnan(a) && !isinf(a);
 }
 
+constexpr inline float8_e4m3fnuz abs(const float8_e4m3fnuz& a) {
+  return (a.rep() & 0x7F) == 0 ? float8_e4m3fnuz::FromRep(a.rep())
+                               : float8_e4m3fnuz::FromRep(a.rep() & 0x7F);
+}
+
+constexpr inline bool isnan(const float8_e4m3fnuz& a) { return a.rep() == 0x80; }
+
+constexpr inline bool isinf(const float8_e4m3fnuz& a) {
+  return false;  // No inf representation.
+}
+
+constexpr inline bool isfinite(const float8_e4m3fnuz& a) {
+  return !isnan(a) && !isinf(a);
+}
+
 constexpr inline float8_e5m2 abs(const float8_e5m2& a) {
   return float8_e5m2::FromRep(a.rep() & 0x7F);
 }
@@ -554,6 +849,23 @@ constexpr inline bool isinf(const float8_e5m2& a) {
 }
 
 constexpr inline bool isfinite(const float8_e5m2& a) {
+  return !isnan(a) && !isinf(a);
+}
+
+constexpr inline float8_e5m2fnuz abs(const float8_e5m2fnuz& a) {
+  return (a.rep() & 0x7F) == 0 ? float8_e5m2fnuz::FromRep(a.rep())
+                               : float8_e5m2fnuz::FromRep(a.rep() & 0x7F);
+}
+
+constexpr inline bool isnan(const float8_e5m2fnuz& a) {
+  return a.rep() == 0x80;
+}
+
+constexpr inline bool isinf(const float8_e5m2fnuz& a) {
+  return false;  // No inf representation.
+}
+
+constexpr inline bool isfinite(const float8_e5m2fnuz& a) {
   return !isnan(a) && !isinf(a);
 }
 
@@ -652,6 +964,38 @@ struct Traits<float8_e4m3b11> : public TraitsBase<float8_e4m3b11> {
       sign = 0;
     }
     return Eigen::numext::bit_cast<float8_e4m3b11>(
+        static_cast<typename Base::BitsType>(bits | sign));
+  }
+};
+
+template <>
+struct Traits<float8_e4m3fnuz> : public TraitsBase<float8_e4m3fnuz> {
+  using Base = TraitsBase<float8_e4m3fnuz>;
+  static constexpr int kExponentBias = 8;
+  static EIGEN_DEVICE_FUNC float8_e4m3fnuz ConstructFromSignAndBits(
+      typename Base::BitsType sign, typename Base::BitsType bits) {
+    // float8_e4m3fnuz does not support signed zero, ignore the sign if we try to
+    // make one.
+    if (bits == 0) {
+      sign = 0;
+    }
+    return Eigen::numext::bit_cast<float8_e4m3fnuz>(
+        static_cast<typename Base::BitsType>(bits | sign));
+  }
+};
+
+template <>
+struct Traits<float8_e5m2fnuz> : public TraitsBase<float8_e5m2fnuz> {
+  using Base = TraitsBase<float8_e5m2fnuz>;
+  static constexpr int kExponentBias = 16;
+  static EIGEN_DEVICE_FUNC float8_e5m2fnuz ConstructFromSignAndBits(
+      typename Base::BitsType sign, typename Base::BitsType bits) {
+    // float8_e5m2fnuz does not support signed zero, ignore the sign if we try to
+    // make one.
+    if (bits == 0) {
+      sign = 0;
+    }
+    return Eigen::numext::bit_cast<float8_e5m2fnuz>(
         static_cast<typename Base::BitsType>(bits | sign));
   }
 };
@@ -930,6 +1274,25 @@ struct ConvertImpl<Eigen::half, float8_e5m2, kTruncate, false> {
   }
 };
 
+template <bool kTruncate, bool kSaturate>
+struct ConvertImpl<Eigen::half, float8_e5m2fnuz, kTruncate, kSaturate> {
+  static EIGEN_DEVICE_FUNC inline float8_e5m2fnuz run(const Eigen::half& from) {
+    // Cast via float because float8_e5m2fnuz and Eigen::half have overlapping
+    // subnormal range.
+    return ConvertImpl<float, float8_e5m2fnuz, kTruncate, kSaturate>::run(from);
+  }
+};
+
+template <bool kTruncate, bool kSaturate>
+struct ConvertImpl<float8_e5m2fnuz, Eigen::half, kTruncate, kSaturate> {
+  static EIGEN_DEVICE_FUNC inline Eigen::half run(const float8_e5m2fnuz& from) {
+    // Cast via float because float8_e5m2fnuz and Eigen::half have overlapping
+    // subnormal range.
+    return static_cast<Eigen::half>(
+        ConvertImpl<float8_e5m2fnuz, float, kTruncate, kSaturate>::run(from));
+  }
+};
+
 // Saturation has no impact when casting Eigen::half to e5m2.
 template <bool kTruncate>
 struct ConvertImpl<Eigen::half, float8_e5m2, /*kSaturate=*/true, kTruncate> {
@@ -973,8 +1336,10 @@ EIGEN_DEVICE_FUNC To float8_base<Derived>::ConvertTo(const Derived& from) {
 
 // Exported types.
 using float8_e4m3fn = float8_internal::float8_e4m3fn;
+using float8_e4m3fnuz = float8_internal::float8_e4m3fnuz;
 using float8_e4m3b11 = float8_internal::float8_e4m3b11;
 using float8_e5m2 = float8_internal::float8_e5m2;
+using float8_e5m2fnuz = float8_internal::float8_e5m2fnuz;
 
 }  // namespace ml_dtypes
 
@@ -1024,8 +1389,20 @@ EIGEN_DEVICE_FUNC inline bool isinf_impl<ml_dtypes::float8_e4m3b11>(
 }
 
 template <>
+EIGEN_DEVICE_FUNC inline bool isinf_impl<ml_dtypes::float8_e4m3fnuz>(
+    const ml_dtypes::float8_e4m3fnuz& x) {
+  return ml_dtypes::float8_internal::isinf(x);
+}
+
+template <>
 EIGEN_DEVICE_FUNC inline bool isinf_impl<ml_dtypes::float8_e5m2>(
     const ml_dtypes::float8_e5m2& x) {
+  return ml_dtypes::float8_internal::isinf(x);
+}
+
+template <>
+EIGEN_DEVICE_FUNC inline bool isinf_impl<ml_dtypes::float8_e5m2fnuz>(
+    const ml_dtypes::float8_e5m2fnuz& x) {
   return ml_dtypes::float8_internal::isinf(x);
 }
 
@@ -1042,8 +1419,20 @@ EIGEN_DEVICE_FUNC inline bool isnan_impl<ml_dtypes::float8_e4m3b11>(
 }
 
 template <>
+EIGEN_DEVICE_FUNC inline bool isnan_impl<ml_dtypes::float8_e4m3fnuz>(
+    const ml_dtypes::float8_e4m3fnuz& x) {
+  return ml_dtypes::float8_internal::isnan(x);
+}
+
+template <>
 EIGEN_DEVICE_FUNC inline bool isnan_impl<ml_dtypes::float8_e5m2>(
     const ml_dtypes::float8_e5m2& x) {
+  return ml_dtypes::float8_internal::isnan(x);
+}
+
+template <>
+EIGEN_DEVICE_FUNC inline bool isnan_impl<ml_dtypes::float8_e5m2fnuz>(
+    const ml_dtypes::float8_e5m2fnuz& x) {
   return ml_dtypes::float8_internal::isnan(x);
 }
 
@@ -1060,8 +1449,20 @@ EIGEN_DEVICE_FUNC inline bool isfinite_impl<ml_dtypes::float8_e4m3b11>(
 }
 
 template <>
+EIGEN_DEVICE_FUNC inline bool isfinite_impl<ml_dtypes::float8_e4m3fnuz>(
+    const ml_dtypes::float8_e4m3fnuz& x) {
+  return ml_dtypes::float8_internal::isfinite(x);
+}
+
+template <>
 EIGEN_DEVICE_FUNC inline bool isfinite_impl<ml_dtypes::float8_e5m2>(
     const ml_dtypes::float8_e5m2& x) {
+  return ml_dtypes::float8_internal::isfinite(x);
+}
+
+template <>
+EIGEN_DEVICE_FUNC inline bool isfinite_impl<ml_dtypes::float8_e5m2fnuz>(
+    const ml_dtypes::float8_e5m2fnuz& x) {
   return ml_dtypes::float8_internal::isfinite(x);
 }
 

--- a/ml_dtypes/tests/custom_float_test.py
+++ b/ml_dtypes/tests/custom_float_test.py
@@ -34,7 +34,9 @@ import numpy as np
 bfloat16 = ml_dtypes.bfloat16
 float8_e4m3b11 = ml_dtypes.float8_e4m3b11
 float8_e4m3fn = ml_dtypes.float8_e4m3fn
+float8_e4m3fnuz = ml_dtypes.float8_e4m3fnuz
 float8_e5m2 = ml_dtypes.float8_e5m2
+float8_e5m2fnuz = ml_dtypes.float8_e5m2fnuz
 
 
 @contextlib.contextmanager
@@ -104,28 +106,36 @@ FLOAT_EPSILON = {
     bfloat16: float.fromhex("1.0p-7"),
     float8_e4m3b11: float.fromhex("1.0p-3"),
     float8_e4m3fn: float.fromhex("1.0p-3"),
+    float8_e4m3fnuz: float.fromhex("1.0p-3"),
     float8_e5m2: float.fromhex("1.0p-2"),
+    float8_e5m2fnuz: float.fromhex("1.0p-2"),
 }
 
 FLOAT_MAX = {
     bfloat16: float.fromhex("1.FEp127"),
     float8_e4m3b11: float.fromhex("1.Ep4"),
     float8_e4m3fn: float.fromhex("1.Cp8"),
+    float8_e4m3fnuz: float.fromhex("1.Ep7"),
     float8_e5m2: float.fromhex("1.Cp15"),
+    float8_e5m2fnuz: float.fromhex("1.Cp15"),
 }
 
 FLOAT_SMALLEST_SUBNORMAL = {
     bfloat16: float.fromhex("1.0p-133"),
     float8_e4m3b11: float.fromhex("1.0p-13"),
     float8_e4m3fn: float.fromhex("1.0p-9"),
+    float8_e4m3fnuz: float.fromhex("1.0p-10"),
     float8_e5m2: float.fromhex("1.0p-16"),
+    float8_e5m2fnuz: float.fromhex("1.0p-17"),
 }
 
 FLOAT_SMALLEST_NORMAL = {
     bfloat16: float.fromhex("1.0p-126"),
     float8_e4m3b11: float.fromhex("1.0p-10"),
     float8_e4m3fn: float.fromhex("1.0p-6"),
+    float8_e4m3fnuz: float.fromhex("1.0p-7"),
     float8_e5m2: float.fromhex("1.0p-14"),
+    float8_e5m2fnuz: float.fromhex("1.0p-15"),
 }
 
 # Values that should round trip exactly to float and back.
@@ -165,7 +175,17 @@ INT_VALUES = {
             range(1 << n, 2 << n, 1 << max(0, n - 3)) for n in range(9)
         )
     )[:-1],
+    float8_e4m3fnuz: list(
+        itertools.chain.from_iterable(
+            range(1 << n, 2 << n, 1 << max(0, n - 3)) for n in range(8)
+        )
+    )[:-1],
     float8_e5m2: list(
+        itertools.chain.from_iterable(
+            range(1 << n, 2 << n, 1 << max(0, n - 2)) for n in range(16)
+        )
+    ),
+    float8_e5m2fnuz: list(
         itertools.chain.from_iterable(
             range(1 << n, 2 << n, 1 << max(0, n - 2)) for n in range(16)
         )
@@ -176,15 +196,26 @@ BITS_TYPE = {
     bfloat16: np.uint16,
     float8_e4m3b11: np.uint8,
     float8_e4m3fn: np.uint8,
+    float8_e4m3fnuz: np.uint8,
     float8_e5m2: np.uint8,
+    float8_e5m2fnuz: np.uint8,
 }
+
+FLOAT_DTYPES = [
+    bfloat16,
+    float8_e4m3b11,
+    float8_e4m3fn,
+    float8_e4m3fnuz,
+    float8_e5m2,
+    float8_e5m2fnuz,
+]
 
 
 # pylint: disable=g-complex-comprehension
 @parameterized.named_parameters(
     (
         {"testcase_name": "_" + dtype.__name__, "float_type": dtype}
-        for dtype in [bfloat16, float8_e4m3b11, float8_e4m3fn, float8_e5m2]
+        for dtype in FLOAT_DTYPES
     )
 )
 class CustomFloatTest(parameterized.TestCase):
@@ -248,7 +279,7 @@ class CustomFloatTest(parameterized.TestCase):
           )
 
   def testBetweenCustomTypes(self, float_type):
-    for dtype in [bfloat16, float8_e4m3b11, float8_e4m3fn, float8_e5m2]:
+    for dtype in FLOAT_DTYPES:
       x = np.array(FLOAT_VALUES[float_type], dtype=dtype)
       y = x.astype(float_type)
       z = x.astype(float).astype(float_type)
@@ -580,7 +611,7 @@ BINARY_PREDICATE_UFUNCS = [
 @parameterized.named_parameters(
     (
         {"testcase_name": "_" + dtype.__name__, "float_type": dtype}
-        for dtype in [bfloat16, float8_e4m3b11, float8_e4m3fn, float8_e5m2]
+        for dtype in FLOAT_DTYPES
     )
 )
 class CustomFloatNumPyTest(parameterized.TestCase):

--- a/ml_dtypes/tests/finfo_test.py
+++ b/ml_dtypes/tests/finfo_test.py
@@ -21,7 +21,9 @@ ALL_DTYPES = [
     ml_dtypes.bfloat16,
     ml_dtypes.float8_e4m3b11,
     ml_dtypes.float8_e4m3fn,
+    ml_dtypes.float8_e4m3fnuz,
     ml_dtypes.float8_e5m2,
+    ml_dtypes.float8_e5m2fnuz,
 ]
 
 UINT_TYPES = {


### PR DESCRIPTION
This change adds support for two additional types `float8_e4m3fnuz` and `float8_e5m2fnuz`. These match the types defined in [LLVM/MLIR](https://mlir.llvm.org/docs/Dialects/Builtin/#float8e5m2fnuztype) and proposed in [StableHLO](https://github.com/openxla/stablehlo/blob/main/rfcs/20230321-fp8_fnuz.md).