### PR TITLE
tests: ignore warning in testCasts

### DIFF
--- a/ml_dtypes/tests/custom_float_test.py
+++ b/ml_dtypes/tests/custom_float_test.py
@@ -659,6 +659,9 @@ class CustomFloatNumPyTest(parameterized.TestCase):
             (d, float_type) in allowed_casts, np.can_cast(d, float_type)
         )
 
+  @ignore_warning(
+      category=RuntimeWarning, message="invalid value encountered in cast"
+  )
   def testCasts(self, float_type):
     for dtype in [
         np.float16,


### PR DESCRIPTION
Should fix the current test failure on main: https://github.com/jax-ml/ml_dtypes/actions/runs/4855480257/jobs/8654065113