### PR TITLE
Remove third party directory from package distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,11 +55,10 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
-[tools.setuptools]
-packages = ["ml_dtypes", "ml_dtypes._src"]
-
-[tool.setuptools.packages]
-find = {}
+[tool.setuptools]
+packages = ["ml_dtypes"]
+include-package-data = false
 
 [tool.setuptools.package-data]
 ml_dtypes = ["py.typed"]
+"ml_dtypes.include" = ["*.h"]

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,5 @@ setup(
             extra_compile_args=COMPILE_ARGS,
         )
     ],
-    include_package_data=True,  # Export headers.
     cmdclass={"build_py": build_py},
 )


### PR DESCRIPTION
Packaging settings at `pyproject.toml` and `setup.py` has been change in version `0.2.0` to include public headers in package distribution. This results in occasional including `third_party/eigen` as well. This pull request fixes the issue.

```
# Before
ml_dtypes
ml_dtypes-0.2.0.dist-info
ml_dtypes.libs
third_party
#After
ml_dtypes
ml_dtypes-0.2.0.dist-info
ml_dtypes.libs
```

Wheel size decreased by 800 kb (from 1 Mb).