### PR TITLE
build: fix requires-python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ml_dtypes"
 version = "0.2.0"  # Keep in sync with ml_dtypes/__init__.py:__version__
 description = ""
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {file = "LICENSE"}
 authors = [{name = "ml_dtypes authors", email="ml_dtypes@google.com"}]
 classifiers = [


### PR DESCRIPTION
I noticed this has been incorrect since the v0.2.0 release: we only test with Python 3.8 and newer.