### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
       - uses: pre-commit/action@v3.0.0
   build:
     name: ${{ matrix.os }} Python ${{ matrix.python-version }}
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12.0-rc.2"]
+        python-version: ["3.9", "3.10", "3.11", "3.12.0-rc.2"]
         include:
           - os: macOS-11
             python-version: "3.11"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_ARCHS_MACOS: universal2
-          CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
+          CIBW_BUILD: cp39-* cp310-* cp311-* cp312-*
           CIBW_SKIP: "*musllinux* *i686* *win32*"
           CIBW_TEST_REQUIRES: absl-py pytest pytest-xdist
           CIBW_TEST_COMMAND: pytest -n auto {project}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: 23.3.1
     hooks:
       - id: pyink
-        language_version: python3.8
+        language_version: python3.9
         args: [
           "--line-length=80",
           "--preview",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,10 @@ To release a new version (e.g. from `1.0.0` -> `2.0.0`):
 
 ## [Unreleased]
 
-## [0.2.0] - 2022-01-06
+* Dropped support for Python 3.8, following [NEP 29].
+* Added support for Python 3.12.
+
+## [0.2.0] - 2023-06-06
 
 * New features:
   * added new 4-bit integer types: `ml_dtypes.int4` and `ml_dtypes.uint4`
@@ -33,10 +36,11 @@ To release a new version (e.g. from `1.0.0` -> `2.0.0`):
     consistency with other dtype names. The former name will still be available until
     version 0.3.0, but will raise a deprecation warning.
 
-## [0.1.0] - 2022-11-01
+## [0.1.0] - 2023-04-11
 
 * Initial release
 
 [Unreleased]: https://github.com/jax-ml/ml_dtypes/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/jax-ml/ml_dtypes/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/jax-ml/ml_dtypes/releases/tag/v0.1.0
+[NEP 29]: https://numpy.org/neps/nep-0029-deprecation_policy.html

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See below for specifications of these number formats.
 
 ## Installation
 
-The `ml_dtypes` package is tested with Python versions 3.8-3.11, and can be installed
+The `ml_dtypes` package is tested with Python versions 3.9-3.12, and can be installed
 with the following command:
 ```
 pip install ml_dtypes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ml_dtypes"
 version = "0.2.0"  # Keep in sync with ml_dtypes/__init__.py:__version__
 description = ""
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 authors = [{name = "ml_dtypes authors", email="ml_dtypes@google.com"}]
 classifiers = [


### PR DESCRIPTION
Following [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html).

@hawkinsp it looks like there's a related TODO here: https://github.com/jax-ml/ml_dtypes/blob/bad6b400d64399f304657756581a296e3d2dbb0b/ml_dtypes/_src/dtypes.cc#L304

I don't entirely understand the comment – how about you send a followup PR once this one is in?