### PR TITLE
Finish deprecation of float8_e4m3b11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ To release a new version (e.g. from `1.0.0` -> `2.0.0`):
 
 * Dropped support for Python 3.8, following [NEP 29].
 * Added support for Python 3.12.
+* Removed deprecated name `ml_dtypes.float8_e4m3b11`;
+  use `ml_dtypes.float8_e4m3b11fnuz` instead.
 
 ## [0.2.0] - 2023-06-06
 

--- a/ml_dtypes/__init__.py
+++ b/ml_dtypes/__init__.py
@@ -51,20 +51,3 @@ int4: Type[np.generic]
 uint4: Type[np.generic]
 
 del np, Type
-
-
-# TODO(jakevdp) remove this deprecated name.
-def __getattr__(name):  # pylint: disable=invalid-name
-  if name == 'float8_e4m3b11':
-    import warnings  # pylint: disable=g-import-not-at-top
-
-    warnings.warn(
-        (
-            'ml_dtypes.float8_e4m3b11 is deprecated. Use'
-            ' ml_dtypes.float8_e4m3b11fnuz'
-        ),
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return float8_e4m3b11fnuz
-  raise AttributeError(f'cannot import name {name!r} from {__name__!r}')


### PR DESCRIPTION
This raised a `DeprecationWarning` since v0.2; remove it for v0.3.