### PR TITLE
Add CMakeLists for C++ tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,3 +27,21 @@ information on using pull requests.
 
 This project follows
 [Google's Open Source Community Guidelines](https://opensource.google/conduct/).
+
+## Testing
+
+To test your changes, you will need to install abseil:
+```
+cd ml_dtypes/test
+git clone https://github.com/abseil/abseil-cpp.git
+cd ../../third_party
+ln -s ../ml_dtypes/tests/abseil-cpp/absl
+```
+
+Run pytest and cmake test as follows:
+```
+pip install -e .
+pytest .
+cmake -B build ml_dtypes/tests
+cmake --build build -- all test
+```

--- a/ml_dtypes/tests/CMakeLists.txt
+++ b/ml_dtypes/tests/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.14)
+project(my_project)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(GOOGLETEST_DOWNLOAD_URL https://github.com/google/googletest/archive/refs/tags/v1.12.0.zip)
+
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL ${GOOGLETEST_DOWNLOAD_URL}
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+set(ABSL_PROPAGATE_CXX_STD ON)
+set(ABSL_GOOGLETEST_DOWNLOAD_URL ${GOOGLETEST_DOWNLOAD_URL})
+add_subdirectory(abseil-cpp)
+
+enable_testing()
+
+add_executable(
+  float8_test
+  float8_test.cc
+)
+target_include_directories(float8_test PUBLIC
+  ..
+  ../..
+  ../../third_party/eigen
+)
+
+target_link_libraries(
+  float8_test
+  GTest::gtest_main
+  GTest::gmock_main
+  absl::strings
+)
+
+include(GoogleTest)
+gtest_discover_tests(float8_test)


### PR DESCRIPTION
This PR makes it easier for outside contributors to run C++ tests.
Should close #76 

I understand there may be a preferred way to do this, but just putting this up as a starting point.