### PR TITLE
CI: add a build against numpy nightly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,3 +50,27 @@ jobs:
       - name: Run tests
         run: |
           pytest -n auto
+  build-nightly:
+    name: Python 3.12 with nightly numpy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+            python -m pip install --upgrade pip
+            python -m pip install setuptools wheel
+            python -m pip install -U --pre numpy \
+              -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+            python -c "import numpy; print(f'{numpy.__version__=}')"
+      - name: Build ml_dtypes
+        run: |
+            python -m pip install .[dev] --no-build-isolation
+      - name: Run tests
+        run: |
+          pytest -n auto

--- a/ml_dtypes/tests/custom_float_test.py
+++ b/ml_dtypes/tests/custom_float_test.py
@@ -37,6 +37,14 @@ float8_e5m2 = ml_dtypes.float8_e5m2
 float8_e5m2fnuz = ml_dtypes.float8_e5m2fnuz
 
 
+try:
+  # numpy >= 2.0
+  ComplexWarning = np.exceptions.ComplexWarning
+except AttributeError:
+  # numpy < 2.0
+  ComplexWarning = np.ComplexWarning
+
+
 @contextlib.contextmanager
 def ignore_warning(**kw):
   with warnings.catch_warnings():
@@ -703,7 +711,7 @@ class CustomFloatNumPyTest(parameterized.TestCase):
       self.assertTrue(np.all(x == z))
       self.assertEqual(dtype, z.dtype)
 
-  @ignore_warning(category=np.ComplexWarning)
+  @ignore_warning(category=ComplexWarning)
   def testConformNumpyComplex(self, float_type):
     for dtype in [np.complex64, np.complex128, np.clongdouble]:
       x = np.array([1.5, 2.5 + 2.0j, 3.5], dtype=dtype)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 filterwarnings =
     error
+    ignore:numpy.core._multiarray_umat.*:DeprecationWarning


### PR DESCRIPTION
~The test is failing, because upstream numpy removed `PyArray_TypeNumFromName` last week (https://github.com/numpy/numpy/pull/25292). This is a real failure that we'd like this test to catch. When I commented-out that part of the source code, tests passed.~

~I propose we merge this as-is, and then work to fix the failure by using an alternative API.~

Fixed in the second commit on the branch.