### PR TITLE
Remove pybind11 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ requires = [
     "numpy~=1.21.2; python_version<'3.11'",
     "numpy~=1.23.3; python_version>='3.11' and python_version<'3.12'",
     "numpy~=1.26.0; python_version>='3.12'",
-    "pybind11~=2.11.1",
     "setuptools~=68.1.0",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@
 import fnmatch
 import platform
 import numpy as np
-from pybind11.setup_helpers import Pybind11Extension
+from setuptools import Extension
 from setuptools import setup
 from setuptools.command.build_py import build_py as build_py_orig
 
@@ -25,11 +25,14 @@ if platform.system() == "Windows":
   COMPILE_ARGS = [
       "/std:c++17",
       "/DEIGEN_MPL2_ONLY",
+      "/EHsc",
+      "/bigobj",
   ]
 else:
   COMPILE_ARGS = [
       "-std=c++17",
       "-DEIGEN_MPL2_ONLY",
+      "-fvisibility=hidden",
       # -ftrapping-math is necessary because NumPy looks at floating point
       # exception state to determine whether to emit, e.g., invalid value
       # warnings. Without this setting, on Mac ARM we see spurious "invalid
@@ -56,7 +59,7 @@ class build_py(build_py_orig):  # pylint: disable=invalid-name
 
 setup(
     ext_modules=[
-        Pybind11Extension(
+        Extension(
             "ml_dtypes._ml_dtypes_ext",
             [
                 "ml_dtypes/_src/dtypes.cc",


### PR DESCRIPTION
It looks like we no longer use this anywhere except in the extension wrapper, which simply adds some compile flags (see https://github.com/pybind/pybind11/blob/v2.11.1/pybind11/setup_helpers.py#L87)

Removing this should help unblock numpy-nightly testing (#129).