### PR TITLE
Fix invalid type registrations under NumPy 2.0.

### DIFF
--- a/ml_dtypes/tests/custom_float_test.py
+++ b/ml_dtypes/tests/custom_float_test.py
@@ -600,6 +600,11 @@ class CustomFloatNumPyTest(parameterized.TestCase):
   def testDtype(self, float_type):
     self.assertEqual(float_type, np.dtype(float_type))
 
+  def testHash(self, float_type):
+    h = hash(np.dtype(float_type))
+    self.assertEqual(h, hash(np.dtype(float_type.dtype)))
+    self.assertEqual(h, hash(np.dtype(float_type.__name__)))
+
   def testDeepCopyDoesNotAlterHash(self, float_type):
     # For context, see https://github.com/google/jax/issues/4651. If the hash
     # value of the type descriptor is not initialized correctly, a deep copy

--- a/ml_dtypes/tests/int4_test.py
+++ b/ml_dtypes/tests/int4_test.py
@@ -225,6 +225,12 @@ class ArrayTest(parameterized.TestCase):
     self.assertEqual(scalar_type, np.dtype(scalar_type))
 
   @parameterized.product(scalar_type=INT4_TYPES)
+  def testHash(self, scalar_type):
+    h = hash(np.dtype(scalar_type))
+    self.assertEqual(h, hash(np.dtype(scalar_type.dtype)))
+    self.assertEqual(h, hash(np.dtype(scalar_type.__name__)))
+
+  @parameterized.product(scalar_type=INT4_TYPES)
   def testDeepCopyDoesNotAlterHash(self, scalar_type):
     # For context, see https://github.com/google/jax/issues/4651. If the hash
     # value of the type descriptor is not initialized correctly, a deep copy


### PR DESCRIPTION
The code was copying a PyArray_Descr object by value, which confused NumPy and meant we ended up with two unrelated type objects, notably one of which had an invalid __hash__.