### PR TITLE
Bump version to 0.4.0b1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,26 @@ jobs:
       - name: Run tests
         run: |
           pytest -n auto
+  # TODO(jakevdp): remove this job after NumPy 2.0 release
+  build-numpy-2-pre:
+    name: Python 3.12 with numpy 2.0 pre-release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.12
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .[dev]
+        pip install -U --pre numpy
+    - name: Run tests
+      run: |
+        pytest -n auto
   build-nightly:
     name: Python 3.12 with nightly numpy
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ To release a new version (e.g. from `1.0.0` -> `2.0.0`):
 
 ## [Unreleased]
 
+## [0.4.0b1] - 2024-03-12
+
+* Updates `ml_dtypes` for compatibility with future NumPy 2.0 release.
+* Wheels for the release candidate are built against NumPy 2.0.0b1.
+
 ## [0.3.2] - 2024-01-03
 
 * Fixed spurious invalid value warnings when casting between floating point
@@ -57,6 +62,7 @@ To release a new version (e.g. from `1.0.0` -> `2.0.0`):
 * Initial release
 
 [Unreleased]: https://github.com/jax-ml/ml_dtypes/compare/v0.3.2...HEAD
+[0.4.0b1]: https://github.com/jax-ml/ml_dtypes/compare/v0.3.2...v0.4.0b1
 [0.3.2]: https://github.com/jax-ml/ml_dtypes/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/jax-ml/ml_dtypes/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/jax-ml/ml_dtypes/compare/v0.2.0...v0.3.0

--- a/ml_dtypes/__init__.py
+++ b/ml_dtypes/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.3.2'  # Keep in sync with pyproject.toml:version
+__version__ = '0.4.0b1'  # Keep in sync with pyproject.toml:version
 __all__ = [
     '__version__',
     'bfloat16',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ml_dtypes"
-version = "0.3.2"  # Keep in sync with ml_dtypes/__init__.py:__version__
+version = "0.4.0b1"  # Keep in sync with ml_dtypes/__init__.py:__version__
 description = ""
 readme = "README.md"
 requires-python = ">=3.9"
@@ -48,10 +48,8 @@ pyink-use-majority-quotes = true
 
 [build-system]
 requires = [
-    # Build with oldest supported numpy for each Python version.
-    "numpy~=1.21.2; python_version<'3.11'",
-    "numpy~=1.23.3; python_version>='3.11' and python_version<'3.12'",
-    "numpy~=1.26.0; python_version>='3.12'",
+    # TODO(jakevdp): update this to 2.0.0rc1 before final release
+    "numpy==2.0.0b1",
     "setuptools~=68.1.0",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
We build the release candidate wheels against NumPy 2.0.0b1. The build artifacts should remain compatible with all supported NumPy versions.

The eventual final 0.4.0 release will be built against NumPy 2.0.0rc1, so that `ml_dtypes` will have a NumPy 2.0-compatible release by the time NumPy 2.0 is released.