### PR TITLE
CI: add ruff pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,7 @@ repos:
           "--pyink-indentation=2",
           "--pyink-use-majority-quotes"
         ]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.2
+    hooks:
+    - id: ruff


### PR DESCRIPTION
This is the linter used by JAX, and catches things like unused imports, etc.