### PR TITLE
Bump version to 0.4.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ To release a new version (e.g. from `1.0.0` -> `2.0.0`):
 
 ## [Unreleased]
 
+## [0.4.0] - 2024-04-1
+
+* Updates `ml_dtypes` for compatibility with future NumPy 2.0 release.
+* Wheels are built against NumPy 2.0.0rc1.
+
 ## [0.4.0b1] - 2024-03-12
 
 * Updates `ml_dtypes` for compatibility with future NumPy 2.0 release.
@@ -61,7 +66,8 @@ To release a new version (e.g. from `1.0.0` -> `2.0.0`):
 
 * Initial release
 
-[Unreleased]: https://github.com/jax-ml/ml_dtypes/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/jax-ml/ml_dtypes/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/jax-ml/ml_dtypes/compare/v0.4.0b1....v0.4.0
 [0.4.0b1]: https://github.com/jax-ml/ml_dtypes/compare/v0.3.2...v0.4.0b1
 [0.3.2]: https://github.com/jax-ml/ml_dtypes/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/jax-ml/ml_dtypes/compare/v0.3.0...v0.3.1

--- a/ml_dtypes/__init__.py
+++ b/ml_dtypes/__init__.py
@@ -12,19 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.4.0b1'  # Keep in sync with pyproject.toml:version
+__version__ = "0.4.0"  # Keep in sync with pyproject.toml:version
 __all__ = [
-    '__version__',
-    'bfloat16',
-    'finfo',
-    'float8_e4m3b11fnuz',
-    'float8_e4m3fn',
-    'float8_e4m3fnuz',
-    'float8_e5m2',
-    'float8_e5m2fnuz',
-    'iinfo',
-    'int4',
-    'uint4',
+    "__version__",
+    "bfloat16",
+    "finfo",
+    "float8_e4m3b11fnuz",
+    "float8_e4m3fn",
+    "float8_e4m3fnuz",
+    "float8_e5m2",
+    "float8_e5m2fnuz",
+    "iinfo",
+    "int4",
+    "uint4",
 ]
 
 from typing import Type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ml_dtypes"
-version = "0.4.0b1"  # Keep in sync with ml_dtypes/__init__.py:__version__
+version = "0.4.0"  # Keep in sync with ml_dtypes/__init__.py:__version__
 description = ""
 readme = "README.md"
 requires-python = ">=3.9"
@@ -48,8 +48,8 @@ pyink-use-majority-quotes = true
 
 [build-system]
 requires = [
-    # TODO(jakevdp): update this to 2.0.0rc1 before final release
-    "numpy==2.0.0b1",
+    # TODO(phawkins): update this to 2.0.0 after its release.
+    "numpy==2.0.0rc1",
     "setuptools~=68.1.0",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
The purpose of this release is to release wheels compatibly with NumPy 2.0, which requires that ml_dtypes is built against NumPy 2.0.0rc1 or later..