### PR TITLE
CI: add test against oldest supported numpy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,26 +50,6 @@ jobs:
       - name: Run tests
         run: |
           pytest -n auto
-  # TODO(jakevdp): remove this job after NumPy 2.0 release
-  build-numpy-2-pre:
-    name: Python 3.12 with numpy 2.0 pre-release
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - name: Set up Python 3.12
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.12
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install .[dev]
-        pip install -U --pre numpy
-    - name: Run tests
-      run: |
-        pytest -n auto
   build-nightly:
     name: Python 3.12 with nightly numpy
     runs-on: ubuntu-latest
@@ -91,6 +71,28 @@ jobs:
       - name: Build ml_dtypes
         run: |
             python -m pip install .[dev] --no-build-isolation
+      - name: Run tests
+        run: |
+          pytest -n auto
+  build-oldest-numpy:
+    name: Python 3.9 with oldest supported numpy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+      - name: Install dependencies
+        run: |
+            python -m pip install --upgrade pip
+            python -m pip install --upgrade setuptools wheel
+      - name: Build ml_dtypes
+        run: |
+            python -m pip install .[dev]
+            python -m pip install numpy==1.21.0  # keep in sync with oldest numpy version in pyproject.toml
       - name: Run tests
         run: |
           pytest -n auto

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ keywords = []
 # pip dependencies of the project
 dependencies = [
     # Ensure numpy release supports Python version.
-    "numpy>1.20",
+    "numpy>=1.21",
     "numpy>=1.21.2; python_version>='3.10'",
     "numpy>=1.23.3; python_version>='3.11'",
     "numpy>=1.26.0; python_version>='3.12'",


### PR DESCRIPTION
We previously had no CI tests directly checking our numpy version compatibility (although there's some indirect coverage via JAX's CI suite).

Related to #156