### PR TITLE
Add float8_e4m3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ To release a new version (e.g. from `1.0.0` -> `2.0.0`):
 
 ## [Unreleased]
 
+* Added new 8-bit float type following IEEE 754 convention:
+  `ml_dtypes.float8_e4m3`.
+
 ## [0.4.0] - 2024-04-1
 
 * Updates `ml_dtypes` for compatibility with future NumPy 2.0 release.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   an alternative to the standard [`float16`](https://en.wikipedia.org/wiki/Half-precision_floating-point_format) format
 - `float8_*`: several experimental 8-bit floating point representations
   including:
+  * `float8_e4m3`
   * `float8_e4m3b11fnuz`
   * `float8_e4m3fn`
   * `float8_e4m3fnuz`
@@ -63,6 +64,10 @@ dtype(float8_e5m2)
 A `bfloat16` number is a single-precision float truncated at 16 bits.
 
 Exponent: 8, Mantissa: 7, exponent bias: 127. IEEE 754, with NaN and inf.
+
+### `float8_e4m3`
+
+Exponent: 4, Mantissa: 3, bias: 7. IEEE 754, with NaN and inf.
 
 ### `float8_e4m3b11fnuz`
 

--- a/ml_dtypes/__init__.py
+++ b/ml_dtypes/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
     "__version__",
     "bfloat16",
     "finfo",
+    "float8_e4m3",
     "float8_e4m3b11fnuz",
     "float8_e4m3fn",
     "float8_e4m3fnuz",
@@ -34,6 +35,7 @@ from typing import Type
 from ml_dtypes._finfo import finfo
 from ml_dtypes._iinfo import iinfo
 from ml_dtypes._ml_dtypes_ext import bfloat16
+from ml_dtypes._ml_dtypes_ext import float8_e4m3
 from ml_dtypes._ml_dtypes_ext import float8_e4m3b11fnuz
 from ml_dtypes._ml_dtypes_ext import float8_e4m3fn
 from ml_dtypes._ml_dtypes_ext import float8_e4m3fnuz
@@ -46,6 +48,7 @@ from ml_dtypes._ml_dtypes_ext import uint4
 import numpy as np
 
 bfloat16: Type[np.generic]
+float8_e4m3: Type[np.generic]
 float8_e4m3b11fnuz: Type[np.generic]
 float8_e4m3fn: Type[np.generic]
 float8_e4m3fnuz: Type[np.generic]

--- a/ml_dtypes/_src/dtypes.cc
+++ b/ml_dtypes/_src/dtypes.cc
@@ -61,6 +61,20 @@ struct TypeDescriptor<bfloat16> : CustomFloatType<bfloat16> {
 };
 
 template <>
+struct TypeDescriptor<float8_e4m3> : CustomFloatType<float8_e4m3> {
+  typedef float8_e4m3 T;
+  static constexpr bool is_floating = true;
+  static constexpr bool is_integral = false;
+  static constexpr const char* kTypeName = "float8_e4m3";
+  static constexpr const char* kQualifiedTypeName = "ml_dtypes.float8_e4m3";
+  static constexpr const char* kTpDoc = "float8_e4m3 floating-point values";
+  // Set e4m3 kind as Void since kind=f (float) with itemsize=1 is used by e5m2
+  static constexpr char kNpyDescrKind = 'V';       // Void
+  static constexpr char kNpyDescrType = '7';       // '4' is reserved for e4m3fn
+  static constexpr char kNpyDescrByteorder = '=';  // Native byte order
+};
+
+template <>
 struct TypeDescriptor<float8_e4m3b11fnuz>
     : CustomFloatType<float8_e4m3b11fnuz> {
   typedef float8_e4m3b11fnuz T;
@@ -269,6 +283,9 @@ bool Initialize() {
   if (!RegisterFloatDtype<bfloat16>(numpy.get())) {
     return false;
   }
+  if (!RegisterFloatDtype<float8_e4m3>(numpy.get())) {
+    return false;
+  }
   if (!RegisterFloatDtype<float8_e4m3b11fnuz>(numpy.get())) {
     return false;
   }
@@ -319,6 +336,12 @@ bool Initialize() {
   success &= RegisterTwoWayCustomCast<float8_e5m2fnuz, float8_e4m3fn, float>();
   success &= RegisterTwoWayCustomCast<float8_e4m3fnuz, float8_e5m2, float>();
   success &= RegisterTwoWayCustomCast<float8_e5m2fnuz, float8_e5m2, float>();
+  success &= RegisterTwoWayCustomCast<float8_e4m3, bfloat16, float>();
+  success &= RegisterTwoWayCustomCast<float8_e4m3, float8_e4m3b11fnuz, float>();
+  success &= RegisterTwoWayCustomCast<float8_e4m3, float8_e5m2fnuz, float>();
+  success &= RegisterTwoWayCustomCast<float8_e4m3, float8_e4m3fnuz, float>();
+  success &= RegisterTwoWayCustomCast<float8_e4m3, float8_e4m3fn, float>();
+  success &= RegisterTwoWayCustomCast<float8_e4m3, float8_e5m2, float>();
   success &= RegisterOneWayCustomCast<int2, int4, int8_t>();
   success &= RegisterOneWayCustomCast<uint2, uint4, uint8_t>();
   return success;
@@ -349,6 +372,11 @@ extern "C" EXPORT_SYMBOL PyObject* PyInit__ml_dtypes_ext() {
     return nullptr;
   }
 
+  if (PyObject_SetAttrString(m.get(), "float8_e4m3",
+                             reinterpret_cast<PyObject*>(
+                                 TypeDescriptor<float8_e4m3>::type_ptr)) < 0) {
+    return nullptr;
+  }
   if (PyObject_SetAttrString(
           m.get(), "float8_e4m3b11fnuz",
           reinterpret_cast<PyObject*>(

--- a/ml_dtypes/tests/custom_float_test.py
+++ b/ml_dtypes/tests/custom_float_test.py
@@ -30,6 +30,7 @@ import ml_dtypes
 import numpy as np
 
 bfloat16 = ml_dtypes.bfloat16
+float8_e4m3 = ml_dtypes.float8_e4m3
 float8_e4m3b11fnuz = ml_dtypes.float8_e4m3b11fnuz
 float8_e4m3fn = ml_dtypes.float8_e4m3fn
 float8_e4m3fnuz = ml_dtypes.float8_e4m3fnuz
@@ -108,6 +109,7 @@ def dtype_has_inf(dtype):
 
 FLOAT_DTYPES = [
     bfloat16,
+    float8_e4m3,
     float8_e4m3b11fnuz,
     float8_e4m3fn,
     float8_e4m3fnuz,
@@ -146,6 +148,11 @@ FLOAT_VALUES = {
 # Values that should round trip exactly to integer and back.
 INT_VALUES = {
     bfloat16: [0, 1, 2, 10, 34, 47, 128, 255, 256, 512],
+    float8_e4m3: list(
+        itertools.chain.from_iterable(
+            range(1 << n, 2 << n, 1 << max(0, n - 3)) for n in range(8)
+        )
+    ),
     float8_e4m3b11fnuz: [*range(16), *range(16, 30, 2)],
     float8_e4m3fn: list(
         itertools.chain.from_iterable(
@@ -171,6 +178,7 @@ INT_VALUES = {
 
 BITS_TYPE = {
     bfloat16: np.uint16,
+    float8_e4m3: np.uint8,
     float8_e4m3b11fnuz: np.uint8,
     float8_e4m3fn: np.uint8,
     float8_e4m3fnuz: np.uint8,

--- a/ml_dtypes/tests/finfo_test.py
+++ b/ml_dtypes/tests/finfo_test.py
@@ -19,6 +19,7 @@ import numpy as np
 
 ALL_DTYPES = [
     ml_dtypes.bfloat16,
+    ml_dtypes.float8_e4m3,
     ml_dtypes.float8_e4m3b11fnuz,
     ml_dtypes.float8_e4m3fn,
     ml_dtypes.float8_e4m3fnuz,


### PR DESCRIPTION
This PR adds `f8E4M3` type.

`f8E4M3` type  follows IEEE 754 convention

```c
f8E4M3 (IEEE 754)
- Exponent bias: 7
- Maximum stored exponent value: 14 (binary 1110)
- Maximum unbiased exponent value: 14 - 7 = 7
- Minimum stored exponent value: 1 (binary 0001)
- Minimum unbiased exponent value: 1 − 7 = −6
- Precision specifies the total number of bits used for the significand (mantisa), 
    including implicit leading integer bit = 3 + 1 = 4
- Follows IEEE 754 conventions for representation of special values
- Has Positive and Negative zero
- Has Positive and Negative infinity
- Has NaNs

Additional details:
- Max exp (unbiased): 7
- Min exp (unbiased): -6
- Infinities (+/-): S.1111.000
- Zeros (+/-): S.0000.000
- NaNs: S.1111.{001, 010, 011, 100, 101, 110, 111}
- Max normal number: S.1110.111 = +/-2^(7) x (1 + 0.875) = +/-240
- Min normal number: S.0001.000 = +/-2^(-6)
- Max subnormal number: S.0000.111 = +/-2^(-6) x 0.875 = +/-2^(-9) x 7
- Min subnormal number: S.0000.001 = +/-2^(-6) x 0.125 = +/-2^(-9)
```

Related LLVM PRs:
- LLVM [PR-97179](https://github.com/llvm/llvm-project/pull/97179) [APFloat] Add support for f8E4M3 IEEE 754 type (Merged)
- LLVM [PR-97118](https://github.com/llvm/llvm-project/pull/97118) [MLIR] Add f8E4M3 IEEE 754 type (Merged)

RFCs:
- [StableHLO PR-2486](https://github.com/openxla/stablehlo/pull/2486) [RFC] Add f8E4M3 and f8E3M4 types support

Related ml_dtypes PRs:
- [PR-57](https://github.com/jax-ml/ml_dtypes/pull/57) Add float8_e4m3fnuz and float8_e5m2fnuz


### C++ Testing

Tested as described in [PR-123](https://github.com/jax-ml/ml_dtypes/pull/123) Add CMakeLists for C++ tests

```
cmake --build build -- all test

100% tests passed, 0 tests failed out of 250

Total Test time (real) =  12.50 sec
```