### PR TITLE
Add .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+BasedOnStyle: Google
+Language: Cpp
+PointerBindsToType: true
+SortIncludes: Never
+AlignTrailingComments:
+  Kind: Always

--- a/ml_dtypes/_src/numpy.cc
+++ b/ml_dtypes/_src/numpy.cc
@@ -21,8 +21,6 @@ limitations under the License.
 
 namespace ml_dtypes {
 
-void ImportNumpy() {
-  import_array1();
-}
+void ImportNumpy() { import_array1(); }
 
 }  // namespace ml_dtypes

--- a/ml_dtypes/include/float8.h
+++ b/ml_dtypes/include/float8.h
@@ -371,8 +371,7 @@ class float8_e5m2 : public float8_base<float8_e5m2> {
 
  public:
   template <typename T, RequiresIsDerivedFromFloat8Base<T> = 0>
-  explicit EIGEN_DEVICE_FUNC float8_e5m2(T f8)
-      : float8_e5m2(ConvertFrom(f8)) {}
+  explicit EIGEN_DEVICE_FUNC float8_e5m2(T f8) : float8_e5m2(ConvertFrom(f8)) {}
 };
 
 class float8_e5m2fnuz : public float8_base<float8_e5m2fnuz> {

--- a/ml_dtypes/tests/intn_test.cc
+++ b/ml_dtypes/tests/intn_test.cc
@@ -143,7 +143,7 @@ struct ConstexprEvaluator {
 // To avoid warnings about unused left-side of comma expressions,
 // we additionally pass the expression through a contexpr function.
 template <typename T>
-constexpr void ConstexprEvaluatorFunc(T&&){}
+constexpr void ConstexprEvaluatorFunc(T&&) {}
 
 #define TEST_CONSTEXPR(expr)                                                   \
   do {                                                                         \


### PR DESCRIPTION
To ensure consistent formatting across .cc and .h files, add a `.clang-format` file to the project. This allows clang-format to automatically apply the desired style when editing files (e.g., in VSCode).

Problem: Without a `.clang-format` file, clang-format defaults to the LLVM style, which differs from the existing formatting in .cc files.

The `.clang-format` file was copied from [OpenXLA/XLA project](https://github.com/openxla/xla/blob/main/.clang-format)