### PR TITLE
Add float8_e3m4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@ To release a new version (e.g. from `1.0.0` -> `2.0.0`):
 
 ## [Unreleased]
 
-* Added new 8-bit float type following IEEE 754 convention:
-  `ml_dtypes.float8_e4m3`.
+* Added new 8-bit float types following IEEE 754 convention:
+  `ml_dtypes.float8_e4m3` and `ml_dtypes.float8_e3m4`.
 * Fix outputs of float `divmod` and `floor_divide` when denominator is zero.
 
 ## [0.4.0] - 2024-04-1

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   an alternative to the standard [`float16`](https://en.wikipedia.org/wiki/Half-precision_floating-point_format) format
 - `float8_*`: several experimental 8-bit floating point representations
   including:
+  * `float8_e3m4`
   * `float8_e4m3`
   * `float8_e4m3b11fnuz`
   * `float8_e4m3fn`
@@ -64,6 +65,10 @@ dtype(float8_e5m2)
 A `bfloat16` number is a single-precision float truncated at 16 bits.
 
 Exponent: 8, Mantissa: 7, exponent bias: 127. IEEE 754, with NaN and inf.
+
+### `float8_e3m4`
+
+Exponent: 3, Mantissa: 4, bias: 3. IEEE 754, with NaN and inf.
 
 ### `float8_e4m3`
 

--- a/ml_dtypes/__init__.py
+++ b/ml_dtypes/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
     "__version__",
     "bfloat16",
     "finfo",
+    "float8_e3m4",
     "float8_e4m3",
     "float8_e4m3b11fnuz",
     "float8_e4m3fn",
@@ -35,6 +36,7 @@ from typing import Type
 from ml_dtypes._finfo import finfo
 from ml_dtypes._iinfo import iinfo
 from ml_dtypes._ml_dtypes_ext import bfloat16
+from ml_dtypes._ml_dtypes_ext import float8_e3m4
 from ml_dtypes._ml_dtypes_ext import float8_e4m3
 from ml_dtypes._ml_dtypes_ext import float8_e4m3b11fnuz
 from ml_dtypes._ml_dtypes_ext import float8_e4m3fn
@@ -48,6 +50,7 @@ from ml_dtypes._ml_dtypes_ext import uint4
 import numpy as np
 
 bfloat16: Type[np.generic]
+float8_e3m4: Type[np.generic]
 float8_e4m3: Type[np.generic]
 float8_e4m3b11fnuz: Type[np.generic]
 float8_e4m3fn: Type[np.generic]

--- a/ml_dtypes/_src/dtypes.cc
+++ b/ml_dtypes/_src/dtypes.cc
@@ -61,6 +61,20 @@ struct TypeDescriptor<bfloat16> : CustomFloatType<bfloat16> {
 };
 
 template <>
+struct TypeDescriptor<float8_e3m4> : CustomFloatType<float8_e3m4> {
+  typedef float8_e3m4 T;
+  static constexpr bool is_floating = true;
+  static constexpr bool is_integral = false;
+  static constexpr const char* kTypeName = "float8_e3m4";
+  static constexpr const char* kQualifiedTypeName = "ml_dtypes.float8_e3m4";
+  static constexpr const char* kTpDoc = "float8_e3m4 floating-point values";
+  // Set e3m4 kind as Void since kind=f (float) with itemsize=1 is used by e5m2
+  static constexpr char kNpyDescrKind = 'V';       // Void
+  static constexpr char kNpyDescrType = '3';
+  static constexpr char kNpyDescrByteorder = '=';  // Native byte order
+};
+
+template <>
 struct TypeDescriptor<float8_e4m3> : CustomFloatType<float8_e4m3> {
   typedef float8_e4m3 T;
   static constexpr bool is_floating = true;
@@ -283,6 +297,9 @@ bool Initialize() {
   if (!RegisterFloatDtype<bfloat16>(numpy.get())) {
     return false;
   }
+  if (!RegisterFloatDtype<float8_e3m4>(numpy.get())) {
+    return false;
+  }
   if (!RegisterFloatDtype<float8_e4m3>(numpy.get())) {
     return false;
   }
@@ -342,6 +359,13 @@ bool Initialize() {
   success &= RegisterTwoWayCustomCast<float8_e4m3, float8_e4m3fnuz, float>();
   success &= RegisterTwoWayCustomCast<float8_e4m3, float8_e4m3fn, float>();
   success &= RegisterTwoWayCustomCast<float8_e4m3, float8_e5m2, float>();
+  success &= RegisterTwoWayCustomCast<float8_e3m4, bfloat16, float>();
+  success &= RegisterTwoWayCustomCast<float8_e3m4, float8_e4m3b11fnuz, float>();
+  success &= RegisterTwoWayCustomCast<float8_e3m4, float8_e5m2fnuz, float>();
+  success &= RegisterTwoWayCustomCast<float8_e3m4, float8_e4m3fnuz, float>();
+  success &= RegisterTwoWayCustomCast<float8_e3m4, float8_e4m3fn, float>();
+  success &= RegisterTwoWayCustomCast<float8_e3m4, float8_e5m2, float>();
+  success &= RegisterTwoWayCustomCast<float8_e3m4, float8_e4m3, float>();
   success &= RegisterOneWayCustomCast<int2, int4, int8_t>();
   success &= RegisterOneWayCustomCast<uint2, uint4, uint8_t>();
   return success;
@@ -372,6 +396,11 @@ extern "C" EXPORT_SYMBOL PyObject* PyInit__ml_dtypes_ext() {
     return nullptr;
   }
 
+  if (PyObject_SetAttrString(m.get(), "float8_e3m4",
+                             reinterpret_cast<PyObject*>(
+                                 TypeDescriptor<float8_e3m4>::type_ptr)) < 0) {
+    return nullptr;
+  }
   if (PyObject_SetAttrString(m.get(), "float8_e4m3",
                              reinterpret_cast<PyObject*>(
                                  TypeDescriptor<float8_e4m3>::type_ptr)) < 0) {

--- a/ml_dtypes/tests/finfo_test.py
+++ b/ml_dtypes/tests/finfo_test.py
@@ -19,6 +19,7 @@ import numpy as np
 
 ALL_DTYPES = [
     ml_dtypes.bfloat16,
+    ml_dtypes.float8_e3m4,
     ml_dtypes.float8_e4m3,
     ml_dtypes.float8_e4m3b11fnuz,
     ml_dtypes.float8_e4m3fn,


### PR DESCRIPTION
This PR adds `f8E3M4` type.

`f8E3M4` type  follows IEEE 754 convention

```c
f8E3M4 (IEEE 754)
- Exponent bias: 3
- Maximum stored exponent value: 6 (binary 110)
- Maximum unbiased exponent value: 6 - 3 = 3
- Minimum stored exponent value: 1 (binary 001)
- Minimum unbiased exponent value: 1 − 3 = −2
- Precision specifies the total number of bits used for the significand (mantissa), 
    including implicit leading integer bit = 4 + 1 = 5
- Follows IEEE 754 conventions for representation of special values
- Has Positive and Negative zero
- Has Positive and Negative infinity
- Has NaNs

Additional details:
- Max exp (unbiased): 3
- Min exp (unbiased): -2
- Infinities (+/-): S.111.0000
- Zeros (+/-): S.000.0000
- NaNs: S.111.{0,1}⁴ except S.111.0000
- Max normal number: S.110.1111 = +/-2^(6-3) x (1 + 15/16) = +/-2^3 x 31 x 2^(-4) = +/-15.5
- Min normal number: S.001.0000 = +/-2^(1-3) x (1 + 0) = +/-2^(-2)
- Max subnormal number: S.000.1111 = +/-2^(-2) x 15/16 = +/-2^(-2) x 15 x 2^(-4) = +/-15 x 2^(-6)
- Min subnormal number: S.000.0001 = +/-2^(-2) x 1/16 =  +/-2^(-2) x 2^(-4) = +/-2^(-6)
```

Related LLVM PRs:
- LLVM [PR-99698](https://github.com/llvm/llvm-project/pull/99698) [APFloat] Add support for f8E3M4 IEEE 754 type (Merged)
- LLVM [PR-101230](https://github.com/llvm/llvm-project/pull/101230) [MLIR] Add f8E3M4 IEEE 754 type (Merged)

RFCs:
- [StableHLO PR-2486](https://github.com/openxla/stablehlo/pull/2486) [RFC] Add f8E4M3 and f8E3M4 types support

Related ml_dtypes PRs:
- [PR-57](https://github.com/jax-ml/ml_dtypes/pull/57) Add float8_e4m3fnuz and float8_e5m2fnuz
- [PR-161](https://github.com/jax-ml/ml_dtypes/pull/161/) Add float8_e4m3


### C++ Testing

Tested as described in [PR-123](https://github.com/jax-ml/ml_dtypes/pull/123) Add CMakeLists for C++ tests

```bash
cmake --build build -- all test

100% tests passed, 0 tests failed out of 307

Total Test time (real) =  14.88 sec
```

### pre-commit code validation

```bash
pre-commit run --all-files
check python ast.........................................................Passed
check for merge conflicts................................................Passed
check toml...............................................................Passed
check yaml...............................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
debug statements (python)................................................Passed
pyink....................................................................Passed
ruff.....................................................................Passed
```