### PR TITLE
CI: update OSX workflows to macos-12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         include:
-          - os: macOS-11
+          - os: macos-12
             python-version: "3.11"
           - os: windows-2019
             python-version: "3.11"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macOS-11, windows-2019]
+        os: [ubuntu-20.04, macos-12, windows-2019]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
macos-11 was deprecated in June 2024 https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/