### PR TITLE
[CI] Allow any python version for pre-commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # ratchet:actions/checkout@v4
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # ratchet:actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # ratchet: pre-commit/action@v3
   build:
     name: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     rev: 8383e5df6527cc1173183875258347be0a7e07c0  # frozen: 24.3.0
     hooks:
       - id: pyink
-        language_version: python3.9
+        language_version: python3.12
         args: [
           "--line-length=80",
           "--preview",


### PR DESCRIPTION
Currently "pre-commit" doesn't work if python3.9 is not installed (e.g. on a typical Ubuntu which has python3.12)