### PR TITLE
Skip test under multithreading

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,9 +8,9 @@ on:
   pull_request:  # trigger on pull requests affecting relevant files
     branches:
       - main
-    paths:
-      - '**workflows/wheels.yml'
-      - 'pyproject.toml'
+    # paths:
+    #   - '**workflows/wheels.yml'
+    #   - 'pyproject.toml'
   release:  # trigger on published release
     types:
       - published

--- a/ml_dtypes/tests/custom_float_test.py
+++ b/ml_dtypes/tests/custom_float_test.py
@@ -672,6 +672,7 @@ BINARY_PREDICATE_UFUNCS = [
         "testUnaryUfunc",
         "testCasts",
         "testLdexp",
+        "testPredicateUfunc",
     ],
 )
 @parameterized.named_parameters(

--- a/ml_dtypes/tests/custom_float_test.py
+++ b/ml_dtypes/tests/custom_float_test.py
@@ -224,7 +224,12 @@ INT_VALUES = {
 # pylint: disable=g-complex-comprehension
 @multi_threaded(
     num_workers=3,
-    skip_tests=["testDiv", "testRoundTripNumpyTypes", "testRoundTripToNumpy"],
+    skip_tests=[
+        "testDiv",
+        "testPicklable",
+        "testRoundTripNumpyTypes",
+        "testRoundTripToNumpy",
+    ],
 )
 @parameterized.named_parameters(
     (
@@ -664,15 +669,19 @@ BINARY_PREDICATE_UFUNCS = [
 @multi_threaded(
     num_workers=3,
     skip_tests=[
+        "testBinaryPredicateUfunc",
         "testBinaryUfunc",
+        "testCasts",
         "testConformNumpyComplex",
-        "testFloordivCornerCases",
+        "testDivmod",
         "testDivmodCornerCases",
+        "testFloordivCornerCases",
+        "testFrexp",
+        "testLdexp",
+        "testModf",
+        "testPredicateUfunc",
         "testSpacing",
         "testUnaryUfunc",
-        "testCasts",
-        "testLdexp",
-        "testPredicateUfunc",
     ],
 )
 @parameterized.named_parameters(
@@ -871,7 +880,6 @@ class CustomFloatNumPyTest(parameterized.TestCase):
             float_type=float_type,
         )
 
-  @ignore_warning(category=RuntimeWarning, message="invalid value encountered")
   def testBinaryPredicateUfunc(self, float_type):
     for op in BINARY_PREDICATE_UFUNCS:
       with self.subTest(op.__name__):

--- a/ml_dtypes/tests/custom_float_test.py
+++ b/ml_dtypes/tests/custom_float_test.py
@@ -226,7 +226,7 @@ INT_VALUES = {
     num_workers=3,
     skip_tests=[
         "testDiv",
-        "testPicklable",
+        "testPickleable",
         "testRoundTripNumpyTypes",
         "testRoundTripToNumpy",
     ],

--- a/ml_dtypes/tests/custom_float_test.py
+++ b/ml_dtypes/tests/custom_float_test.py
@@ -880,6 +880,7 @@ class CustomFloatNumPyTest(parameterized.TestCase):
             float_type=float_type,
         )
 
+  @ignore_warning(category=RuntimeWarning, message="invalid value encountered")
   def testBinaryPredicateUfunc(self, float_type):
     for op in BINARY_PREDICATE_UFUNCS:
       with self.subTest(op.__name__):

--- a/ml_dtypes/tests/finfo_test.py
+++ b/ml_dtypes/tests/finfo_test.py
@@ -55,7 +55,7 @@ UINT_TYPES = {
 }
 
 
-@multi_threaded(num_workers=3)
+@multi_threaded(num_workers=3, skip_tests=["testFInfo"])
 class FinfoTest(parameterized.TestCase):
 
   def assertNanEqual(self, x, y):


### PR DESCRIPTION
This is failing due to warning control being incompatible with multithreading.