### PR TITLE
Fix eigen::numext::signbit for MXFloat types (fp6/fp4)

### DIFF
--- a/ml_dtypes/include/mxfloat.h
+++ b/ml_dtypes/include/mxfloat.h
@@ -338,7 +338,7 @@ struct Traits<float4_e2m1fn>
 namespace Eigen {
 namespace numext {
 
-#define MXFLOAT_EIGEN_BITCAST_IMPL(Type)                                 \
+#define MXFLOAT_EIGEN_BITCAST_AND_SIGNBIT_IMPL(Type)                     \
   template <>                                                            \
   EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC uint8_t bit_cast<uint8_t, Type>( \
       const Type& x) {                                                   \
@@ -348,11 +348,16 @@ namespace numext {
   EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC Type bit_cast<Type, uint8_t>(    \
       const uint8_t& x) {                                                \
     return Type::FromRep(x);                                             \
+  }                                                                      \
+  template <>                                                            \
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE Type signbit(const Type& x) {    \
+    int8_t t = bit_cast<int8_t, Type>(x) << (8 - Type::kBits);           \
+    return bit_cast<Type, int8_t>(t >> 7);                               \
   }
 
-MXFLOAT_EIGEN_BITCAST_IMPL(ml_dtypes::float6_e2m3fn)
-MXFLOAT_EIGEN_BITCAST_IMPL(ml_dtypes::float6_e3m2fn)
-MXFLOAT_EIGEN_BITCAST_IMPL(ml_dtypes::float4_e2m1fn)
+MXFLOAT_EIGEN_BITCAST_AND_SIGNBIT_IMPL(ml_dtypes::float6_e2m3fn)
+MXFLOAT_EIGEN_BITCAST_AND_SIGNBIT_IMPL(ml_dtypes::float6_e3m2fn)
+MXFLOAT_EIGEN_BITCAST_AND_SIGNBIT_IMPL(ml_dtypes::float4_e2m1fn)
 
 #undef MXFLOAT_EIGEN_BITCAST_IMPL
 

--- a/ml_dtypes/tests/mxfloat_test.cc
+++ b/ml_dtypes/tests/mxfloat_test.cc
@@ -125,6 +125,14 @@ TYPED_TEST(FloatMXTest, Negate) {
   }
 }
 
+TYPED_TEST(FloatMXTest, Signbit) {
+  using FloatMX = TypeParam;
+
+  FloatMX one(1.0);
+  EXPECT_EQ(Eigen::numext::signbit(one).rep(), 0x00);
+  EXPECT_EQ(Eigen::numext::signbit(-one).rep(), 0xff);
+}
+
 TYPED_TEST(FloatMXTest, BitCasts) {
   using FloatMX = TypeParam;
 


### PR DESCRIPTION
The default Eigen implementation checks the highest bit (7) to determine if a number is signed.
For less-than-8-bit types, this is incorrect - so add the template specialization for these types.

Note that "eigen::numext::signbit" returns all-zero-bits for an unsigned input, and all-one-bits for signed input.
For 8-bit types, this is `0x00` for unsigned and `0xFF` for signed.

Note: this was previously not picked up by the tests, as this project doesn't use the "eigen::numext::signbit" function, but other projects do (e.g. OpenXLA).