### PR TITLE
Enabled free-threading multithread tests and added more skips

### DIFF
--- a/ml_dtypes/tests/custom_float_test.py
+++ b/ml_dtypes/tests/custom_float_test.py
@@ -27,7 +27,7 @@ import warnings
 from absl.testing import absltest
 from absl.testing import parameterized
 import ml_dtypes
-# from multi_thread_utils import multi_threaded
+from multi_thread_utils import multi_threaded
 import numpy as np
 
 bfloat16 = ml_dtypes.bfloat16
@@ -221,12 +221,16 @@ INT_VALUES = {
 }
 
 
-# TODO(jakevdp): re-enable multi-threaded tests after 0.5.0 release.
 # pylint: disable=g-complex-comprehension
-# @multi_threaded(
-#     num_workers=3,
-#     skip_tests=["testDiv", "testRoundTripNumpyTypes", "testRoundTripToNumpy"],
-# )
+@multi_threaded(
+    num_workers=3,
+    skip_tests=[
+        "testDiv",
+        "testPickleable",
+        "testRoundTripNumpyTypes",
+        "testRoundTripToNumpy",
+    ],
+)
 @parameterized.named_parameters(
     (
         {"testcase_name": "_" + dtype.__name__, "float_type": dtype}
@@ -661,21 +665,25 @@ BINARY_PREDICATE_UFUNCS = [
 ]
 
 
-# TODO(jakevdp): re-enable multi-threaded tests after 0.5.0 release.
 # pylint: disable=g-complex-comprehension
-# @multi_threaded(
-#     num_workers=3,
-#     skip_tests=[
-#         "testBinaryUfunc",
-#         "testConformNumpyComplex",
-#         "testFloordivCornerCases",
-#         "testDivmodCornerCases",
-#         "testSpacing",
-#         "testUnaryUfunc",
-#         "testCasts",
-#         "testLdexp",
-#     ],
-# )
+@multi_threaded(
+    num_workers=3,
+    skip_tests=[
+        "testBinaryPredicateUfunc",
+        "testBinaryUfunc",
+        "testCasts",
+        "testConformNumpyComplex",
+        "testDivmod",
+        "testDivmodCornerCases",
+        "testFloordivCornerCases",
+        "testFrexp",
+        "testLdexp",
+        "testModf",
+        "testPredicateUfunc",
+        "testSpacing",
+        "testUnaryUfunc",
+    ],
+)
 @parameterized.named_parameters(
     (
         {"testcase_name": "_" + dtype.__name__, "float_type": dtype}

--- a/ml_dtypes/tests/finfo_test.py
+++ b/ml_dtypes/tests/finfo_test.py
@@ -15,7 +15,7 @@
 from absl.testing import absltest
 from absl.testing import parameterized
 import ml_dtypes
-# from multi_thread_utils import multi_threaded
+from multi_thread_utils import multi_threaded
 import numpy as np
 
 ALL_DTYPES = [
@@ -55,8 +55,7 @@ UINT_TYPES = {
 }
 
 
-# TODO(jakevdp): re-enable multi-threaded tests after 0.5.0 release.
-# @multi_threaded(num_workers=3)
+@multi_threaded(num_workers=3)
 class FinfoTest(parameterized.TestCase):
 
   def assertNanEqual(self, x, y):

--- a/ml_dtypes/tests/iinfo_test.py
+++ b/ml_dtypes/tests/iinfo_test.py
@@ -15,12 +15,11 @@
 from absl.testing import absltest
 from absl.testing import parameterized
 import ml_dtypes
-# from multi_thread_utils import multi_threaded
+from multi_thread_utils import multi_threaded
 import numpy as np
 
 
-# TODO(jakevdp): re-enable multi-threaded tests after 0.5.0 release.
-# @multi_threaded(num_workers=3)
+@multi_threaded(num_workers=3)
 class IinfoTest(parameterized.TestCase):
 
   def testIinfoInt2(self):

--- a/ml_dtypes/tests/intn_test.py
+++ b/ml_dtypes/tests/intn_test.py
@@ -23,7 +23,7 @@ import warnings
 from absl.testing import absltest
 from absl.testing import parameterized
 import ml_dtypes
-# from multi_thread_utils import multi_threaded
+from multi_thread_utils import multi_threaded
 import numpy as np
 
 int2 = ml_dtypes.int2
@@ -48,9 +48,8 @@ def ignore_warning(**kw):
     yield
 
 
-# TODO(jakevdp): re-enable multi-threaded tests after 0.5.0 release.
 # Tests for the Python scalar type
-# @multi_threaded(num_workers=3)
+@multi_threaded(num_workers=3)
 class ScalarTest(parameterized.TestCase):
 
   @parameterized.product(scalar_type=INTN_TYPES)
@@ -247,9 +246,8 @@ class ScalarTest(parameterized.TestCase):
     )
 
 
-# TODO(jakevdp): re-enable multi-threaded tests after 0.5.0 release.
 # Tests for the Python scalar type
-# @multi_threaded(num_workers=3, skip_tests=["testBinaryUfuncs"])
+@multi_threaded(num_workers=3, skip_tests=["testBinaryUfuncs"])
 class ArrayTest(parameterized.TestCase):
 
   @parameterized.product(scalar_type=INTN_TYPES)

--- a/ml_dtypes/tests/metadata_test.py
+++ b/ml_dtypes/tests/metadata_test.py
@@ -16,11 +16,10 @@ from importlib import metadata
 
 from absl.testing import absltest
 import ml_dtypes
-# from multi_thread_utils import multi_threaded
+from multi_thread_utils import multi_threaded
 
 
-# TODO(jakevdp): re-enable multi-threaded tests after 0.5.0 release.
-# @multi_threaded(num_workers=3)
+@multi_threaded(num_workers=3)
 class CustomFloatTest(absltest.TestCase):
 
   def test_version_matches_package_metadata(self):


### PR DESCRIPTION
Description:
- reverted https://github.com/jax-ml/ml_dtypes/pull/191
- Added more skips from https://github.com/jax-ml/ml_dtypes/pull/188


When running stress tests as following:
```bash
while python -m pytest -n 50  -vvv; do :; done
```
We get more numpy errors:
```
FAILED ml_dtypes/tests/intn_test.py::ArrayTest::testCasts0_multi_threaded - TypeError: Cannot cast array data from dtype('float16') to dtype(int2) according to the rule 'unsafe'

FAILED ml_dtypes/tests/intn_test.py::ArrayTest::testCasts48_multi_threaded - TypeError: Cannot cast array data from dtype('complex64') to dtype(uint2) according to the rule 'unsafe'

FAILED ml_dtypes/tests/intn_test.py::ArrayTest::testCasts44_multi_threaded - TypeError: Cannot cast array data from dtype(uint2) to dtype('int8') according to the rule 'unsafe'

FAILED ml_dtypes/tests/intn_test.py::ArrayTest::testCasts69_multi_threaded - TypeError: Cannot cast array data from dtype('complex128') to dtype(uint4) according to the rule 'unsafe'


E       Traceback (most recent call last):
E         File "/usr/local/lib/python3.13t/dist-packages/numpy/_core/numeric.py", line 2476, in isclose
E           dt = multiarray.result_type(y, 1.)
E       RuntimeError: A cast was already added for <class 'numpy.dtypes.Float16DType'> -> <class 'numpy.dtype[float8_e5m2]'>. (method: legacy_cast)
E       
E       For more information see https://pluggy.readthedocs.io/en/stable/api_reference.html#pluggy.PluggyTeardownRaisedWarning

/usr/local/lib/python3.13t/dist-packages/pluggy/_callers.py:50: PluggyTeardownRaisedWarning
========================================================================================================= short test summary info =========================================================================================================
FAILED ml_dtypes/tests/finfo_test.py::FinfoTest::testFInfo_float8_e5m2_multi_threaded - pluggy.PluggyTeardownRaisedWarning: A plugin raised an exception during an old-style hookwrapper teardown.


>         self.assertEqual(
              (float_type, d) in allowed_casts, np.can_cast(float_type, d)
          )
E         AssertionError: True != False

ml_dtypes/tests/custom_float_test.py:781: AssertionError
========================================================================================================= short test summary info =========================================================================================================
FAILED ml_dtypes/tests/custom_float_test.py::CustomFloatNumPyTest::testCanCast_float8_e8m0fnu_multi_threaded - AssertionError: True != False
FAILED ml_dtypes/tests/custom_float_test.py::CustomFloatNumPyTest::testCanCast_float8_e4m3fnuz_multi_threaded - AssertionError: True != False
```

Numpy code:
- https://github.com/numpy/numpy/blob/4206d096253dee344eb9b5c11abd83b3f03ecc57/numpy/_core/src/multiarray/convert_datatype.c#L809-L815

