### PR TITLE
Fix rounded_from_bits casting in float8.h

### DIFF
--- a/ml_dtypes/include/float8.h
+++ b/ml_dtypes/include/float8.h
@@ -1555,7 +1555,7 @@ struct ConvertImpl<From, To, kSaturate, kTruncate,
     } else if constexpr (kDigitShift >= 0) {
       // Shift up, inserting zeros in the newly created digits.
       rounded_from_bits <<= kDigitShift;
-      bits = ToBits{rounded_from_bits};
+      bits = static_cast<ToBits>(rounded_from_bits);
     }
 
     To to = Eigen::numext::bit_cast<To>(bits);


### PR DESCRIPTION
Currently XLA `bazel build //xla:literal_test` fails with error (Clang 18)
```
In file included from xla/literal.cc:16:
In file included from ./xla/literal.h:41:
In file included from ./xla/array.h:36:
In file included from ./xla/types.h:27:
In file included from external/tsl/tsl/platform/ml_dtypes.h:19:
bazel-out/k8-opt/bin/external/ml_dtypes/_virtual_includes/float8/ml_dtypes/include/float8.h:1343:21: error: non-constant-expression cannot be narrowed from type 'WideBits' (aka 'unsigned short') to 'ToBits' (aka 'unsigned char') in initializer list [-Wc++11-narrowing]
 1343 |       bits = ToBits{rounded_from_bits};
      |                     ^~~~~~~~~~~~~~~~~
```

### Solution:

Narrowing conversions in an initializer list, is not allowed in C++11 and later without an explicit cast.

We need to explicitly cast the value to the target type (ToBits) to indicate that we are aware of the potential narrowing

@jakevdp Can you have a look?