### PR TITLE
[NFC] Remove unnecessary override for Eigen::numext::bit_cast

### DIFF
--- a/ml_dtypes/include/float8.h
+++ b/ml_dtypes/include/float8.h
@@ -1689,63 +1689,10 @@ using float8_e8m0fnu = float8_internal::float8_e8m0fnu;
 
 }  // namespace ml_dtypes
 
-// Eigen-specific overrides.
-namespace Eigen {
-namespace numext {
-
-template <>
-EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC ml_dtypes::float8_e3m4
-bit_cast<ml_dtypes::float8_e3m4, uint8_t>(const uint8_t& src) {
-  return ml_dtypes::float8_e3m4::FromRep(src);
-}
-
-template <>
-EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC uint8_t
-bit_cast<uint8_t, ml_dtypes::float8_e3m4>(const ml_dtypes::float8_e3m4& src) {
-  return src.rep();
-}
-
-template <>
-EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC ml_dtypes::float8_e4m3
-bit_cast<ml_dtypes::float8_e4m3, uint8_t>(const uint8_t& src) {
-  return ml_dtypes::float8_e4m3::FromRep(src);
-}
-
-template <>
-EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC uint8_t
-bit_cast<uint8_t, ml_dtypes::float8_e4m3>(const ml_dtypes::float8_e4m3& src) {
-  return src.rep();
-}
-
-template <>
-EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC ml_dtypes::float8_e4m3fn
-bit_cast<ml_dtypes::float8_e4m3fn, uint8_t>(const uint8_t& src) {
-  return ml_dtypes::float8_e4m3fn::FromRep(src);
-}
-
-template <>
-EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC uint8_t
-bit_cast<uint8_t, ml_dtypes::float8_e4m3fn>(
-    const ml_dtypes::float8_e4m3fn& src) {
-  return src.rep();
-}
-
-template <>
-EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC ml_dtypes::float8_e5m2
-bit_cast<ml_dtypes::float8_e5m2, uint8_t>(const uint8_t& src) {
-  return ml_dtypes::float8_e5m2::FromRep(src);
-}
-
-template <>
-EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC uint8_t
-bit_cast<uint8_t, ml_dtypes::float8_e5m2>(const ml_dtypes::float8_e5m2& src) {
-  return src.rep();
-}
-
-}  // namespace numext
-
 // Work-around for isinf/isnan/isfinite issue on aarch64.
+namespace Eigen {
 namespace internal {
+
 template <>
 EIGEN_DEVICE_FUNC inline bool isinf_impl<ml_dtypes::float8_e3m4>(
     const ml_dtypes::float8_e3m4& x) {

--- a/ml_dtypes/include/mxfloat.h
+++ b/ml_dtypes/include/mxfloat.h
@@ -338,28 +338,18 @@ struct Traits<float4_e2m1fn>
 namespace Eigen {
 namespace numext {
 
-#define MXFLOAT_EIGEN_BITCAST_AND_SIGNBIT_IMPL(Type)                     \
-  template <>                                                            \
-  EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC uint8_t bit_cast<uint8_t, Type>( \
-      const Type& x) {                                                   \
-    return x.rep();                                                      \
-  }                                                                      \
-  template <>                                                            \
-  EIGEN_STRONG_INLINE EIGEN_DEVICE_FUNC Type bit_cast<Type, uint8_t>(    \
-      const uint8_t& x) {                                                \
-    return Type::FromRep(x);                                             \
-  }                                                                      \
-  template <>                                                            \
-  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE Type signbit(const Type& x) {    \
-    int8_t t = bit_cast<int8_t, Type>(x) << (8 - Type::kBits);           \
-    return bit_cast<Type, int8_t>(t >> 7);                               \
+#define MXFLOAT_EIGEN_SIGNBIT_IMPL(Type)                              \
+  template <>                                                         \
+  EIGEN_DEVICE_FUNC EIGEN_ALWAYS_INLINE Type signbit(const Type& x) { \
+    int8_t t = bit_cast<int8_t, Type>(x) << (8 - Type::kBits);        \
+    return bit_cast<Type, int8_t>(t >> 7);                            \
   }
 
-MXFLOAT_EIGEN_BITCAST_AND_SIGNBIT_IMPL(ml_dtypes::float6_e2m3fn)
-MXFLOAT_EIGEN_BITCAST_AND_SIGNBIT_IMPL(ml_dtypes::float6_e3m2fn)
-MXFLOAT_EIGEN_BITCAST_AND_SIGNBIT_IMPL(ml_dtypes::float4_e2m1fn)
+MXFLOAT_EIGEN_SIGNBIT_IMPL(ml_dtypes::float6_e2m3fn)
+MXFLOAT_EIGEN_SIGNBIT_IMPL(ml_dtypes::float6_e3m2fn)
+MXFLOAT_EIGEN_SIGNBIT_IMPL(ml_dtypes::float4_e2m1fn)
 
-#undef MXFLOAT_EIGEN_BITCAST_IMPL
+#undef MXFLOAT_EIGEN_SIGNBIT_IMPL
 
 }  // namespace numext
 


### PR DESCRIPTION
The default Eigen implementation (https://gitlab.com/libeigen/eigen/-/blob/master/Eigen/src/Core/NumTraits.h#L101-115) does the simple data copy, so the overrides are not necessary.