### PR TITLE
Add ppc64le Architecture Support for Wheel Builds on Ubuntu

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -50,7 +50,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           # TODO(jakevdp): re-add 313t & free-threading support
-          CIBW_ARCHS_LINUX: auto aarch64
+          CIBW_ARCHS_LINUX: auto aarch64 ppc64le
           CIBW_ARCHS_MACOS: universal2
           CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-* # cp313t-*
           # CIBW_FREE_THREADED_SUPPORT: True


### PR DESCRIPTION
This PR introduces support for the ppc64le architecture to enable building wheels for Power architecture on the Ubuntu platform. By adding ppc64le to the list of supported architectures, this change aims to facilitate the creation and distribution of ml_dtypes wheels for Power systems.

Request:
Please review these changes to ensure compatibility, and if approved, merge them so that we can begin generating and publishing ml_dtypes wheels for Power architecture.

