### PR TITLE
Don't set NPY_NEEDS_PYAPI.

### DIFF
--- a/ml_dtypes/_src/custom_float.h
+++ b/ml_dtypes/_src/custom_float.h
@@ -401,7 +401,7 @@ PyArray_DescrProto GetCustomFloatDescrProto() {
       /*kind=*/TypeDescriptor<T>::kNpyDescrKind,
       /*type=*/TypeDescriptor<T>::kNpyDescrType,
       /*byteorder=*/TypeDescriptor<T>::kNpyDescrByteorder,
-      /*flags=*/NPY_NEEDS_PYAPI | NPY_USE_SETITEM,
+      /*flags=*/NPY_USE_SETITEM,
       /*type_num=*/0,
       /*elsize=*/sizeof(T),
       /*alignment=*/alignof(T),

--- a/ml_dtypes/_src/intn_numpy.h
+++ b/ml_dtypes/_src/intn_numpy.h
@@ -413,7 +413,7 @@ PyArray_DescrProto GetIntNDescrProto() {
       /*kind=*/TypeDescriptor<T>::kNpyDescrKind,
       /*type=*/TypeDescriptor<T>::kNpyDescrType,
       /*byteorder=*/TypeDescriptor<T>::kNpyDescrByteorder,
-      /*flags=*/NPY_NEEDS_PYAPI | NPY_USE_SETITEM,
+      /*flags=*/NPY_USE_SETITEM,
       /*type_num=*/0,
       /*elsize=*/sizeof(T),
       /*alignment=*/alignof(T),


### PR DESCRIPTION
We don't need NumPy to retain the GIL during access, and it triggers a crash in NumPy: https://github.com/numpy/numpy/issues/27709#issuecomment-2461655819