### PR TITLE
Enable free-threaded wheels in wheel builds.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -49,11 +49,10 @@ jobs:
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          # TODO(jakevdp): re-add 313t & free-threading support
           CIBW_ARCHS_LINUX: auto aarch64 ppc64le
           CIBW_ARCHS_MACOS: universal2
-          CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-* # cp313t-*
-          # CIBW_FREE_THREADED_SUPPORT: True
+          CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-* cp313t-*
+          CIBW_FREE_THREADED_SUPPORT: True
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_SKIP: "*musllinux* *i686* *win32* *t-win*"
           CIBW_TEST_REQUIRES: absl-py pytest pytest-xdist


### PR DESCRIPTION
We should merge
https://github.com/jax-ml/ml_dtypes/pull/203

to reenable the tests, but I would like to ship the wheels in a release.

Fixes https://github.com/jax-ml/ml_dtypes/issues/228