### PR TITLE
`include/float8.h:NextPowerOfTwo`; infinite values

### DIFF
--- a/ml_dtypes/include/float8.h
+++ b/ml_dtypes/include/float8.h
@@ -1194,26 +1194,19 @@ template <typename T>
 bool constexpr IsPowerOfTwo(T x) {
   return (x != 0) && ((x & (x - 1)) == 0);
 }
+template <unsigned int N>
+constexpr unsigned int MostSignificantBit() {
+  unsigned int result = 0;
+  unsigned int x = N;
+  while (x >>= 1) {
+    ++result;
+  }
+  return result; // return N == 0 ? 0 : (sizeof(long long) * 8 - 1 - __builtin_clz(N));
+}
 // Helper for getting a bytes size which is a power of two.
 template <int Size>
 struct NextPowerOfTwo {
-  static constexpr int value = Size;
-};
-template <>
-struct NextPowerOfTwo<3> {
-  static constexpr int value = 4;
-};
-template <>
-struct NextPowerOfTwo<5> {
-  static constexpr int value = 8;
-};
-template <>
-struct NextPowerOfTwo<6> {
-  static constexpr int value = 8;
-};
-template <>
-struct NextPowerOfTwo<7> {
-  static constexpr int value = 8;
+  static constexpr int value = 1 << MostSignificantBit<Size>();
 };
 
 // Helper for getting a bit representation provided a byte size.


### PR DESCRIPTION
+`ml_dtypes/include/float8.h:MostSignificantBit`; `constexpr` version of `clz` opcode. *`ml_dtypes/include/float8.h:NextPowerOfTwo`; replace long list of hardcoded values with `1 << MostSignificantBit<Size>`, which extends `NextPowerOfTwo` (was limited to integer sizes, now is less code plus is general use).