### PR TITLE
@`ml_dtypes/include/float8.h` comment fixes

### DIFF
--- a/ml_dtypes/include/float8.h
+++ b/ml_dtypes/include/float8.h
@@ -733,7 +733,7 @@ struct numeric_limits_float8_e4m3fn : public numeric_limits_float8_base {
   static constexpr float8_e4m3fn min() {
     return float8_e4m3fn::FromRep(0b0'0001 << kMantissaBits);
   }
-  // -(1 + 0b110 * 2^-3) * 2^(0b1111 - 7) = -1.75 * 2^8 = 448
+  // -(1 + 0b110 * 2^-3) * 2^(0b1111 - 7) = -1.75 * 2^8 = -448
   static constexpr float8_e4m3fn lowest() {
     return float8_e4m3fn::FromRep(0b1'1111'110);
   }
@@ -1635,7 +1635,7 @@ EIGEN_DEVICE_FUNC Derived float8_base<Derived>::ConvertFrom(const From from) {
   // rounding is odd." 17th IMACS World Congress. 2005.
   if constexpr (std::is_floating_point_v<From> &&
                 sizeof(From) > sizeof(double)) {
-    // binary64, float80, binary128, etc. end up here.
+    // float80, binary128, etc. end up here.
     static_assert(std::numeric_limits<From>::digits >=
                   std::numeric_limits<float>::digits + 2);
     static_assert(std::numeric_limits<float>::min_exponent >=


### PR DESCRIPTION
[R740](https://github.com/jax-ml/ml_dtypes/pull/292/files#diff-6d10d01d258305f8e53bc0d3e09e28642909b03807ecb5a8cd56239feb0bdcc8R740): The comment value for `float8_e4m3fn max()` is now the complement of the comment value for `float8_e4m3fn lowest()`
[R1638](https://github.com/jax-ml/ml_dtypes/pull/292/files#diff-6d10d01d258305f8e53bc0d3e09e28642909b03807ecb5a8cd56239feb0bdcc8R1638): This branch path is for types with size greater than `double` (`binary64`), so removed `binary64` from the list of types which use this branch path.

The full context (which "Files changed" does not show) for the originals is:
https://github.com/jax-ml/ml_dtypes/blob/1527272ef82990434e637c1545c8ae93141b43f1/ml_dtypes/include/float8.h#L736-L743
([`main`](https://github.com/jax-ml/ml_dtypes/blob/1527272ef82990434e637c1545c8ae93141b43f1/ml_dtypes/include/float8.h#L736-L743) has both comments end with `= 448`, which does not reflect the calculus truth).