### PR TITLE
Prepare for 0.5.3 release.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,17 +28,32 @@ jobs:
           python-version: 3.12
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
   build:
-    name: ${{ matrix.os }} Python ${{ matrix.python-version }}
+    name: ${{ matrix.os }} Python ${{ matrix.python-version }} freethreaded ${{ matrix.freethreaded }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14.0-rc.1"]
+        freethreaded: [false, true]
+        exclude:
+          - python-version: 3.9
+            freethreaded: true
+          - python-version: 3.10
+            freethreaded: true
+          - python-version: 3.11
+            freethreaded: true
+          - python-version: 3.12
+            freethreaded: true
         include:
           - os: macos-14
             python-version: "3.12"
+            freethreaded: false
           - os: windows-2022
             python-version: "3.12"
+            freethreaded: false
+          - os: windows-11-arm
+            python-version: "3.12"
+            freethreaded: false
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
@@ -49,6 +64,7 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
+          freethreaded: ${{ matrix.freethreaded }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -101,35 +117,6 @@ jobs:
         run: |
             python -m pip install .[dev]
             python -m pip install numpy==1.21.0  # keep in sync with oldest numpy version in pyproject.toml
-      - name: Run tests
-        run: |
-          pytest -n auto
-  build-free-threading:
-    # Later we can merge this job with build similarly to
-    # https://github.com/python-pillow/Pillow/blob/f0d8fd3059bc1b291563d8a0b1f224b6fd7d0b90/.github/workflows/test.yml#L56-L57
-    name: Python 3.13 with free-threading
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-        with:
-          submodules: true
-          persist-credentials: false
-      - name: Set up Python 3.13 with free-threading
-        # TODO: replace with setup-python when there is support
-        uses: deadsnakes/action@e640ac8743173a67cca4d7d77cd837e514bf98e8 # v3.2.0
-        with:
-            python-version: '3.13-dev'
-            nogil: true
-      - name: Install dependencies
-        run: |
-            python -m pip install --upgrade pip
-            python -m pip install setuptools wheel
-            python -m pip install -U --pre numpy \
-              -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-            python -c "import numpy; print(f'{numpy.__version__=}')"
-      - name: Build ml_dtypes
-        run: |
-            python -m pip install .[dev] --no-build-isolation
       - name: Run tests
         run: |
           pytest -n auto

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -28,6 +28,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-22.04-arm, macos-14, windows-2022]
+        cibw_build: ["cp39-* cp310-* cp311-* cp312-* cp313-* cp313t-* cp314-* cp314t-*"]
+        include:
+          - os: windows-11-arm
+            cibw_build: "cp311-* cp312-* cp313-* cp313t-* cp314-* cp314t-*"
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
@@ -37,18 +41,18 @@ jobs:
       # Used to host cibuildwheel
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
-          python-version: "3.9"
+          python-version: "3.12"
 
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.20.0
+        run: python -m pip install cibuildwheel==3.1.2
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS_LINUX: auto
           CIBW_ARCHS_MACOS: universal2
-          CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-* cp313t-*
-          CIBW_FREE_THREADED_SUPPORT: True
+          CIBW_BUILD: ${{ matrix.cibw_build }}
+          CIBW_ENABLE: cpython-freethreading
           CIBW_PRERELEASE_PYTHONS: True
           CIBW_SKIP: "*musllinux* *i686* *win32* *t-win*"
           CIBW_TEST_REQUIRES: absl-py pytest pytest-xdist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ To release a new version (e.g. from `1.0.0` -> `2.0.0`):
 
 ## [Unreleased]
 
+## [0.5.3] - 2025-07-29
+
+  * NPY_NEEDS_PYAPI was removed from the dtype flags. This should improve the
+    speed of array operations, but it does mean that values pickled using
+    previous versions of ml_dtypes are incompatible with the current release
+    and should be regenerated with the current release.
+  * Wheels now support Python 3.14.
+  * Wheels now support Windows 11 ARM.
+
 ## [0.5.2] - 2025-01-31
 
  * Dropped support for Power wheels again. These turned out to cause problems in

--- a/ml_dtypes/__init__.py
+++ b/ml_dtypes/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.1"
+__version__ = "0.5.3"
 __all__ = [
     "__version__",
     "bfloat16",

--- a/ml_dtypes/tests/intn_test.py
+++ b/ml_dtypes/tests/intn_test.py
@@ -278,7 +278,8 @@ class ScalarTest(parameterized.TestCase):
     # But these shouldn't raise exceptions.
     np.array(np.nan).astype(scalar_type)
     np.array(np.inf).astype(scalar_type)
-    np.array(1e10).astype(scalar_type)
+    with np.errstate(invalid="ignore"):
+      np.array(1e10).astype(scalar_type)
 
 
 # Tests for the Python scalar type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ml_dtypes"
 dynamic = ["version"]  # Load from ml_dtypes.__version__.
-description = ""
+description = "ml_dtypes is a stand-alone implementation of several NumPy dtype extensions used in machine learning."
 readme = "README.md"
 requires-python = ">=3.9"
 license = "Apache-2.0"


### PR DESCRIPTION
* Update changelog.
* Add 3.14 wheels to build matrix.
* Add Windows 11 ARM wheels.