### PR TITLE
Fix bfloat16 byteswap

### DIFF
--- a/ml_dtypes/_src/custom_float.h
+++ b/ml_dtypes/_src/custom_float.h
@@ -481,32 +481,41 @@ void NPyCustomFloat_CopySwapN(void* dstv, npy_intp dstride, void* srcv,
                 "Not supported");
   char* dst = reinterpret_cast<char*>(dstv);
   char* src = reinterpret_cast<char*>(srcv);
-  if (!src) {
-    return;
-  }
-  if (swap && sizeof(T) == sizeof(int16_t)) {
-    for (npy_intp i = 0; i < n; i++) {
-      char* r = dst + dstride * i;
-      memcpy(r, src + sstride * i, sizeof(T));
-      ByteSwap16(r);
+  
+  if (src) {
+    if (swap && sizeof(T) == sizeof(int16_t)) {
+      for (npy_intp i = 0; i < n; i++) {
+        char* r = dst + dstride * i;
+        memcpy(r, src + sstride * i, sizeof(T));
+        ByteSwap16(r);
+      }
+    } else if (dstride == sizeof(T) && sstride == sizeof(T)) {
+      memcpy(dst, src, n * sizeof(T));
+    } else {
+      for (npy_intp i = 0; i < n; i++) {
+        memcpy(dst + dstride * i, src + sstride * i, sizeof(T));
+      }
     }
-  } else if (dstride == sizeof(T) && sstride == sizeof(T)) {
-    memcpy(dst, src, n * sizeof(T));
   } else {
-    for (npy_intp i = 0; i < n; i++) {
-      memcpy(dst + dstride * i, src + sstride * i, sizeof(T));
+    // In-place swap when src is NULL
+    if (swap && sizeof(T) == sizeof(int16_t)) {
+      for (npy_intp i = 0; i < n; i++) {
+        char* r = dst + dstride * i;
+        ByteSwap16(r);
+      }
     }
   }
 }
 
 template <typename T>
 void NPyCustomFloat_CopySwap(void* dst, void* src, int swap, void* arr) {
-  if (!src) {
-    return;
-  }
-  memcpy(dst, src, sizeof(T));
   static_assert(sizeof(T) == sizeof(int16_t) || sizeof(T) == sizeof(int8_t),
                 "Not supported");
+  
+  if (src) {
+    memcpy(dst, src, sizeof(T));
+  }
+  
   if (swap && sizeof(T) == sizeof(int16_t)) {
     ByteSwap16(dst);
   }

--- a/ml_dtypes/_src/intn_numpy.h
+++ b/ml_dtypes/_src/intn_numpy.h
@@ -480,24 +480,25 @@ void NPyIntN_CopySwapN(void* dstv, npy_intp dstride, void* srcv,
                        npy_intp sstride, npy_intp n, int swap, void* arr) {
   char* dst = reinterpret_cast<char*>(dstv);
   char* src = reinterpret_cast<char*>(srcv);
-  if (!src) {
-    return;
-  }
-  if (dstride == sizeof(T) && sstride == sizeof(T)) {
-    memcpy(dst, src, n * sizeof(T));
-  } else {
-    for (npy_intp i = 0; i < n; i++) {
-      memcpy(dst + dstride * i, src + sstride * i, sizeof(T));
+  
+  if (src) {
+    if (dstride == sizeof(T) && sstride == sizeof(T)) {
+      memcpy(dst, src, n * sizeof(T));
+    } else {
+      for (npy_intp i = 0; i < n; i++) {
+        memcpy(dst + dstride * i, src + sstride * i, sizeof(T));
+      }
     }
   }
+  // Note: No byte swapping needed for 8-bit integer types
 }
 
 template <typename T>
 void NPyIntN_CopySwap(void* dst, void* src, int swap, void* arr) {
-  if (!src) {
-    return;
+  if (src) {
+    memcpy(dst, src, sizeof(T));
   }
-  memcpy(dst, src, sizeof(T));
+  // Note: No byte swapping needed for 8-bit integer types
 }
 
 template <typename T>

--- a/ml_dtypes/tests/custom_float_test.py
+++ b/ml_dtypes/tests/custom_float_test.py
@@ -626,6 +626,33 @@ class CustomFloatTest(parameterized.TestCase):
         self.assertEqual(type(expected), type(actual))
         self.assertEqual(float(expected), float(actual))
 
+  def testByteSwap(self, float_type):
+    """Test that byteswap works correctly."""
+    arr = np.array([1.0, 2.0, 3.0], dtype=float_type)
+    original_bytes = arr.tobytes()
+    
+    # Test copy byteswap
+    swapped = arr.byteswap(inplace=False)
+    self.assertIsNot(swapped, arr)  # Different object
+    self.assertEqual(arr.tobytes(), original_bytes)  # Original unchanged
+    
+    if np.dtype(float_type).itemsize == 2:
+      # 16-bit types should swap bytes
+      self.assertNotEqual(original_bytes, swapped.tobytes())
+      
+      # Test in-place byteswap
+      arr_copy = arr.copy()
+      result = arr_copy.byteswap(inplace=True)
+      self.assertIs(result, arr_copy)  # Same object
+      self.assertEqual(arr_copy.tobytes(), swapped.tobytes())  # Same bytes
+      
+      # Double swap restores original
+      arr_copy.byteswap(inplace=True)
+      self.assertEqual(arr_copy.tobytes(), original_bytes)
+    else:
+      # 8-bit types should be unchanged
+      self.assertEqual(original_bytes, swapped.tobytes())
+
 
 BinaryOp = collections.namedtuple("BinaryOp", ["op"])
 


### PR DESCRIPTION
## Problem
The `byteswap()` function wasn't working for bfloat16 arrays. Instead of swapping bytes, it returned the same array.

 ## Root Cause
 When NumPy calls byteswap, it passes `src=NULL` to tell our code "swap the bytes in place". But our code was seeing `src=NULL` and doing nothing instead of swapping.

 ## Solution
  Fixed the copyswap functions to swap bytes when `src=NULL`.

  ## Testing
- Added test that verifies byteswap works for bfloat16
- Confirmed the original issue #308 is now fixed
- All existing tests still pass

  ## Changes
- `ml_dtypes/_src/custom_float.h`: Fixed copyswap functions
- `ml_dtypes/_src/intn_numpy.h`: Same fix for consistency
- `ml_dtypes/tests/custom_float_test.py`: Added test

Fixes #308