### PR TITLE
Adapt Python version 3.14-dev to final release in GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14.0-rc.1"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14.0"]
         freethreaded: [false, true]
         exclude:
           - python-version: 3.9


### PR DESCRIPTION
Updated Python version from 3.14.0-rc.1 to 3.14.0 in workflow.