### PR TITLE
[maint] drop Python 3.9 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,11 +33,9 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         freethreaded: [false, true]
         exclude:
-          - python-version: 3.9
-            freethreaded: true
           - python-version: 3.10
             freethreaded: true
           - python-version: 3.11
@@ -107,17 +105,17 @@ jobs:
         run: |
           pytest -n auto
   build-oldest-numpy:
-    name: Python 3.9 with oldest supported numpy
+    name: Python 3.10 with oldest supported numpy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           submodules: true
           persist-credentials: false
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6.0.0
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install dependencies
         run: |
             python -m pip install --upgrade pip

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-22.04-arm, macos-14, windows-2022]
-        cibw_build: ["cp39-* cp310-* cp311-* cp312-* cp313-* cp313t-* cp314-* cp314t-*"]
+        cibw_build: ["cp310-* cp311-* cp312-* cp313-* cp313t-* cp314-* cp314t-*"]
         include:
           - os: windows-11-arm
             cibw_build: "cp311-* cp312-* cp313-* cp313t-* cp314-* cp314t-*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ To release a new version (e.g. from `1.0.0` -> `2.0.0`):
 
 ## [Unreleased]
 
+* Drop support for Python 3.9, which reached end-of-life in October 2025.
+
 ## [0.5.4] - 2025-11-17
 
 * We now register casts from int2 and int4 to all of the custom float types,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ml_dtypes"
 dynamic = ["version"]  # Load from ml_dtypes.__version__.
 description = "ml_dtypes is a stand-alone implementation of several NumPy dtype extensions used in machine learning."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 license-files = ["LICENSE", "LICENSE.eigen"]
 authors = [{name = "ml_dtypes authors", email="ml_dtypes@google.com"}]
@@ -17,11 +17,11 @@ keywords = []
 # pip dependencies of the project
 dependencies = [
     # Ensure numpy release supports Python version.
-    "numpy>=1.21",
-    "numpy>=1.21.2; python_version>='3.10'",
+    "numpy>=1.21.2",
     "numpy>=1.23.3; python_version>='3.11'",
     "numpy>=1.26.0; python_version>='3.12'",
     "numpy>=2.1.0; python_version>='3.13'",
+    "numpy>=2.3.0; python_version>='3.14'",
 ]
 
 [project.urls]


### PR DESCRIPTION
Python 3.9 hit its end of life in October 2025: https://devguide.python.org/versions/

The [0.5.4 release](https://pypi.org/project/ml-dtypes/0.5.4/) is the last `ml_dtypes` release to support Python 3.9; subsequent releases will require Python 3.10 or newer.