### PR TITLE
Change type chars and document complex

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@
   * `uint1`
   * `uint2`
   * `uint4`
+- 16-bit complex floating point numbers. (See below below for important limitations.)
+  * `complex32` (matching `numpy.float16`)
+  * `bcomplex32` (matching `numpy.bfloat16`)
 
 See below for specifications of these number formats.
 
@@ -185,6 +188,16 @@ engineering project. These types therefore use an unpacked representation, where
 each element of the array is padded up to a byte in memory. The lower two or four
 bits of each byte contain the representation of the number, whereas the remaining
 upper bits are ignored.
+
+## `complex32` and `bcomplex32`
+
+Complex types corresponding to `numpy.float16` and `ml_dtypes.bfloat16` respectively.
+
+Because NumPy currently only recognizes built-in complex types the array
+attributes `arr.imag` and `arr.real` will give incorrect results
+(`.imag` returns an array of complex zeros and `.real` the original values unchanged).
+To mitigate this issue we provide `ml_dtypes.imag()` and `ml_dtypes.real()`.
+Similarly, other functions may fail to apply the correct complex behavior.
 
 ## Quirks of low-precision Arithmetic
 

--- a/ml_dtypes/_src/complex.cc
+++ b/ml_dtypes/_src/complex.cc
@@ -539,15 +539,16 @@ namespace {
 //
 // Note on kind and type character in NumPy 1.x:
 // 1. Custom complex types use kind='V' (Void) to avoid conflation with NumPy's
-//    built-in complex dtypes.
-// 2. Type characters ('P' for bcomplex32, 'O' for complex32) are assigned on a
+//    built-in complex dtypes. The exception is complex32, which uses kind='c'
+//    as the standard complex float16 type.
+// 2. Type characters ('K' for bcomplex32, 'J' for complex32) are assigned on a
 //    best-effort basis; 'E' was already used by bfloat16.
 template <typename T>
 PyArray_DescrProto GetCustomComplexDescrProto() {
   return {
       PyObject_HEAD_INIT(nullptr)
       /*typeobj=*/nullptr,  // Filled in later
-      /*kind=*/'V',
+      /*kind=*/std::is_same_v<T, complex32> ? 'c' : 'V',
       /*type=*/CustomComplexTraits<T>::kNumPy1DescrType,
       /*byteorder=*/'=',
       /*flags=*/NPY_USE_SETITEM,

--- a/ml_dtypes/_src/complex.h
+++ b/ml_dtypes/_src/complex.h
@@ -32,7 +32,7 @@ struct CustomComplexTraits<bcomplex32> {
   static constexpr const char* kQualifiedTypeName = "ml_dtypes.bcomplex32";
   static constexpr const char* kTpDoc =
       "complex bfloat16 floating-point values";
-  static constexpr char kNumPy1DescrType = 'P';
+  static constexpr char kNumPy1DescrType = 'K';
 };
 
 template <>
@@ -40,7 +40,7 @@ struct CustomComplexTraits<complex32> {
   static constexpr const char* kTypeName = "complex32";
   static constexpr const char* kQualifiedTypeName = "ml_dtypes.complex32";
   static constexpr const char* kTpDoc = "complex half floating-point values";
-  static constexpr char kNumPy1DescrType = 'O';
+  static constexpr char kNumPy1DescrType = 'J';
 };
 
 template <typename T, typename = void>

--- a/ml_dtypes/_src/dtypes.cc
+++ b/ml_dtypes/_src/dtypes.cc
@@ -349,10 +349,8 @@ struct TypeDescriptor<bcomplex32> : CustomComplexType<bcomplex32> {
   static constexpr const char* kTpDoc =
       "complex bfloat16 floating-point values";
   // See also bfloat16, the kind argument is tricky to choose well.
-  static constexpr char kNpyDescrKind = 'W';  // TODO(seberg): better name?
-  // TODO(phawkins): there doesn't seem to be a way of guaranteeing a type
-  // character is unique.
-  static constexpr char kNpyDescrType = 'P';  // TODO(seberg): better name?
+  static constexpr char kNpyDescrKind = 'V';
+  static constexpr char kNpyDescrType = 'K';
   static constexpr char kNpyDescrByteorder = '=';
 };
 
@@ -366,10 +364,10 @@ struct TypeDescriptor<complex32> : CustomComplexType<complex32> {
   static constexpr const char* kQualifiedTypeName = "ml_dtypes.complex32";
   static constexpr const char* kTpDoc = "complex half floating-point values";
   // See also bfloat16. `E` type char is used for bfloat16 unfortunately.
-  static constexpr char kNpyDescrKind = 'W';  // TODO(seberg): better name?
+  static constexpr char kNpyDescrKind = 'c';  // TODO(seberg): better name?
   // TODO(phawkins): there doesn't seem to be a way of guaranteeing a type
   // character is unique.
-  static constexpr char kNpyDescrType = 'O';  // TODO(seberg): better name?
+  static constexpr char kNpyDescrType = 'J';
   static constexpr char kNpyDescrByteorder = '=';
 };
 


### PR DESCRIPTION
This may be more for discussion. If we want unique type characters things are just annoying. Not that type characters matter much so long that we don't collide with NumPy's.

This is a suggestion to change `E` to mean complex32 to follow the NumPy pattern on this one, but that means changing bfloat16 to something else, right now `r` (and bcomplex32 `R`).

(The truth is, there is no good choice, beyond just setting it `\0` some time and maybe defaulting in NumPy to return something else then -- or doing it here via the new API.)