### PR TITLE
Fix custom float dtype f-string formatting truncating exponent notation

### DIFF
--- a/ml_dtypes/_src/custom_float.h
+++ b/ml_dtypes/_src/custom_float.h
@@ -354,6 +354,40 @@ Py_hash_t PyCustomFloat_Hash(PyObject* self) {
 }
 
 template <typename T>
+PyObject* PyCustomFloat_Format(PyObject* self, PyObject* args) {
+  PyObject* format_spec = nullptr;
+  if (!PyArg_ParseTuple(args, "U", &format_spec)) {
+    return nullptr;
+  }
+
+  T x = reinterpret_cast<PyCustomFloat<T>*>(self)->value;
+  float f = static_cast<float>(x);
+
+  // Round to 6 significant digits to match PyCustomFloat_Str/Repr, which
+  // use std::ostringstream with its default precision of 6. This avoids
+  // exposing false precision from the float64 expansion.
+  char buf[14];  // max %.6g output: "-9.98378e+38" + '\0' = 14
+  std::snprintf(buf, sizeof(buf), "%.6g", static_cast<double>(f));
+  double d = std::strtod(buf, nullptr);
+
+  PyObject* float_obj = PyFloat_FromDouble(d);
+  if (!float_obj) {
+    return nullptr;
+  }
+
+  PyObject* result = PyObject_Format(float_obj, format_spec);
+  Py_DECREF(float_obj);
+  return result;
+}
+
+template <typename T>
+PyMethodDef CustomFloatType_methods[] = {
+    {"__format__", PyCustomFloat_Format<T>, METH_VARARGS,
+     "Format a custom float value."},
+    {nullptr, nullptr, 0, nullptr},
+};
+
+template <typename T>
 PyType_Slot CustomFloatType<T>::type_slots[] = {
     {Py_tp_new, reinterpret_cast<void*>(PyCustomFloat_New<T>)},
     {Py_tp_repr, reinterpret_cast<void*>(PyCustomFloat_Repr<T>)},
@@ -362,6 +396,7 @@ PyType_Slot CustomFloatType<T>::type_slots[] = {
     {Py_tp_doc,
      reinterpret_cast<void*>(const_cast<char*>(TypeDescriptor<T>::kTpDoc))},
     {Py_tp_richcompare, reinterpret_cast<void*>(PyCustomFloat_RichCompare<T>)},
+    {Py_tp_methods, reinterpret_cast<void*>(CustomFloatType_methods<T>)},
     {Py_nb_add, reinterpret_cast<void*>(PyCustomFloat_Add<T>)},
     {Py_nb_subtract, reinterpret_cast<void*>(PyCustomFloat_Subtract<T>)},
     {Py_nb_multiply, reinterpret_cast<void*>(PyCustomFloat_Multiply<T>)},

--- a/ml_dtypes/_src/custom_float.h
+++ b/ml_dtypes/_src/custom_float.h
@@ -361,13 +361,11 @@ PyObject* PyCustomFloat_Format(PyObject* self, PyObject* args) {
   }
 
   T x = reinterpret_cast<PyCustomFloat<T>*>(self)->value;
-  float f = static_cast<float>(x);
-
   // Round to 6 significant digits to match PyCustomFloat_Str/Repr, which
   // use std::ostringstream with its default precision of 6. This avoids
   // exposing false precision from the float64 expansion.
   char buf[14];  // max %.6g output: "-9.98378e+38" + '\0' = 14
-  std::snprintf(buf, sizeof(buf), "%.6g", static_cast<double>(f));
+  std::snprintf(buf, sizeof(buf), "%.6g", static_cast<double>(x));
   double d = std::strtod(buf, nullptr);
 
   PyObject* float_obj = PyFloat_FromDouble(d);


### PR DESCRIPTION
This PR fixes #341.

Formatting custom float scalars (e.g. `bfloat16`) would fallback to `np.generic.__format__` and be truncated by string length.

```bash
python -c "from ml_dtypes import bfloat16; print(f'{bfloat16(1e-6):.8}')"
```
> `9.98378e`  — exponent "-07" truncated

This PR adds a `__format__` method to all custom float types that:
1. Rounds the value to 6 significant digits, which matches the default precision of `std::ostringstream` from `PyCustomFloat_Str`/`Repr` methods.
2. Delegates to `float.__format__` for the actual formatting.

After the fix:
```bash
python -c "from ml_dtypes import bfloat16; print(f'{bfloat16(1e-6):.8}')"
```
> `9.98378e-07`

```bash
python -c "from ml_dtypes import bfloat16; print(f'{bfloat16(1e-6):.8e}')"
```
> `9.98378000e-07` — padding digits beyond precision with zeros