### PR TITLE
Create zizmor.yml

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read # only needed for private repos
+      actions: read # only needed for private repos
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@135698455da5c3b3e55f73f4419e481ab68cdd95 # v0.4.1

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -13,8 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       security-events: write
-      contents: read # only needed for private repos
-      actions: read # only needed for private repos
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -22,4 +20,4 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@135698455da5c3b3e55f73f4419e481ab68cdd95 # v0.4.1
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6


### PR DESCRIPTION
## What this PR does
This PR introduces [zizmor](https://woodruff.dev/zizmor/), a static analysis tool for GitHub Actions workflows, and fixes the supply chain security issues it identifies across all existing workflow files.

### New workflow: `zizmor.yml`
Adds a CI job that runs zizmor on every push to `main` and on every pull request. zizmor audits `.github/workflows/` for common security misconfigurations including:
- **Unpinned actions** — version tags like `@v4` are mutable; they can be silently updated or hijacked. zizmor requires every `uses:` reference to be pinned to an immutable SHA hash.
- **Excessive permissions** — workflows that request write permissions they do not need.
- **Script injection risks** — untrusted user input flowing into `run:` steps without sanitization.
- **Credential leaks** — credentials inadvertently persisted across steps.

Results are uploaded as SARIF to GitHub's Security tab so findings are surfaced directly alongside code review.

### Why SHA pinning?
When a workflow references `actions/checkout@v4`, GitHub resolves the `v4` tag at runtime. A compromised or mistakenly updated tag silently changes the code that executes in your CI environment — with access to secrets and the ability to modify build outputs. Pinning to a full 40-character commit SHA makes that reference immutable: the exact same code runs on every invocation, and any change to the referenced action is immediately visible in the diff.

The comment (`# v4`, `# stable`, etc.) preserved alongside each SHA makes it easy for humans to understand what version is pinned and for tools like [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot) or [zizmor](https://woodruff.dev/zizmor/) to suggest upgrades.

### Ecosystem alignment
This change reflects a broader shift in the ML ecosystem toward supply chain security as a baseline. As ONNX and projects like ml_dtypes evolve their dependencies and infrastructure, securing the CI/CD pipeline—starting with immutable action pinning and least-privilege permissions—becomes essential for maintainers and users alike.