### PR TITLE
Add cooldown configuration to Dependabot update schedules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,11 @@ updates:
       interval: weekly
     ignore:
       - dependency-name: "numpy"
+    cooldown:
+      default-days: 7
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary

- Add `cooldown: default-days: 7` to the `pip` and `github-actions` Dependabot ecosystems in `.github/dependabot.yml`

This was flagged by [zizmor](https://github.com/woodruffw/zizmor)'s [`dependabot-cooldown`](https://docs.zizmor.sh/audits/#dependabot-cooldown) audit. Without a cooldown, Dependabot can open many PRs in quick succession, leaving little time for review before a potential auto-merge. A 7-day cooldown (matching the existing weekly schedule) prevents that.

The fix was generated with `zizmor --fix`.

## Test plan

- [x] Run `zizmor .github/dependabot.yml` — no findings reported after this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)