### PR TITLE
Implement __format__ for custom float, complex, and int dtypes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ To release a new version (e.g. from `1.0.0` -> `2.0.0`):
 
 ## [Unreleased]
 
+* Added `__format__` method to custom float, complex, and integer types
+  ([#341](https://github.com/jax-ml/ml_dtypes/issues/341)). Previously,
+  formatting custom scalars (e.g. in f-strings) fell back to string formatting,
+  which could truncate exponents or fail on numeric format specifiers.
 * Dropped support for Python 3.9, which reached end-of-life in October 2025.
 * Dropped support for Python 3.13 free-threading, because cibuildwheel dropped support.
 * Dropped support for NumPy < 1.24.

--- a/ml_dtypes/_src/custom_complex.h
+++ b/ml_dtypes/_src/custom_complex.h
@@ -483,10 +483,29 @@ PyObject* PyCustomComplex_Imag<complex32>(PyObject* self, PyObject*) {
   return scalar.release();
 }
 
+// Format function for PyCustomComplex.
+template <typename T>
+PyObject* PyCustomComplex_Format(PyObject* self, PyObject* format_spec) {
+  if (!PyUnicode_Check(format_spec)) {
+    PyErr_Format(PyExc_TypeError, "__format__() argument 1 must be str, not %s",
+                 Py_TYPE(format_spec)->tp_name);
+    return nullptr;
+  }
+  PyObject* c = PyCustomComplex_Complex<T>(self, nullptr);
+  if (!c) {
+    return nullptr;
+  }
+  PyObject* result = PyObject_Format(c, format_spec);
+  Py_DECREF(c);
+  return result;
+}
+
 template <typename T>
 PyMethodDef CustomComplexType<T>::methods[] = {
     {"__complex__", reinterpret_cast<PyCFunction>(PyCustomComplex_Complex<T>),
      METH_NOARGS, "Convert to Python complex"},
+    {"__format__", reinterpret_cast<PyCFunction>(PyCustomComplex_Format<T>),
+     METH_O, "Format a custom complex value."},
     {NULL, NULL, 0, NULL}};
 
 template <typename T>

--- a/ml_dtypes/_src/custom_float.h
+++ b/ml_dtypes/_src/custom_float.h
@@ -61,6 +61,7 @@ struct CustomFloatType {
   // registered by another system into NumPy.
   static PyObject* type_ptr;
 
+  static PyMethodDef methods[];
   static PyType_Spec type_spec;
   static PyType_Slot type_slots[];
   static PyArray_ArrFuncs arr_funcs;
@@ -358,6 +359,30 @@ Py_hash_t PyCustomFloat_Hash(PyObject* self) {
   return HashImpl(&_Py_HashDouble, self, static_cast<double>(x));
 }
 
+// Format function for PyCustomFloat.
+template <typename T>
+PyObject* PyCustomFloat_Format(PyObject* self, PyObject* format_spec) {
+  if (!PyUnicode_Check(format_spec)) {
+    PyErr_Format(PyExc_TypeError, "__format__() argument 1 must be str, not %s",
+                 Py_TYPE(format_spec)->tp_name);
+    return nullptr;
+  }
+  PyObject* f = PyCustomFloat_Float<T>(self);
+  if (!f) {
+    return nullptr;
+  }
+  PyObject* result = PyObject_Format(f, format_spec);
+  Py_DECREF(f);
+  return result;
+}
+
+template <typename T>
+PyMethodDef CustomFloatType<T>::methods[] = {
+    {"__format__", reinterpret_cast<PyCFunction>(PyCustomFloat_Format<T>),
+     METH_O, "Format a custom float value."},
+    {nullptr, nullptr, 0, nullptr},
+};
+
 template <typename T>
 PyType_Slot CustomFloatType<T>::type_slots[] = {
     {Py_tp_new, reinterpret_cast<void*>(PyCustomFloat_New<T>)},
@@ -367,6 +392,7 @@ PyType_Slot CustomFloatType<T>::type_slots[] = {
     {Py_tp_doc,
      reinterpret_cast<void*>(const_cast<char*>(TypeDescriptor<T>::kTpDoc))},
     {Py_tp_richcompare, reinterpret_cast<void*>(PyCustomFloat_RichCompare<T>)},
+    {Py_tp_methods, reinterpret_cast<void*>(CustomFloatType<T>::methods)},
     {Py_nb_add, reinterpret_cast<void*>(PyCustomFloat_Add<T>)},
     {Py_nb_subtract, reinterpret_cast<void*>(PyCustomFloat_Subtract<T>)},
     {Py_nb_multiply, reinterpret_cast<void*>(PyCustomFloat_Multiply<T>)},

--- a/ml_dtypes/_src/intn_numpy.h
+++ b/ml_dtypes/_src/intn_numpy.h
@@ -50,6 +50,7 @@ struct IntNTypeDescriptor {
   // registered by another system into NumPy.
   static PyObject* type_ptr;
 
+  static PyMethodDef methods[];
   static PyType_Spec type_spec;
   static PyType_Slot type_slots[];
 
@@ -382,6 +383,30 @@ PyObject* PyIntN_RichCompare(PyObject* a, PyObject* b, int op) {
   PyArrayScalar_RETURN_BOOL_FROM_LONG(result);
 }
 
+// Format function for PyIntN.
+template <typename T>
+PyObject* PyIntN_Format(PyObject* self, PyObject* format_spec) {
+  if (!PyUnicode_Check(format_spec)) {
+    PyErr_Format(PyExc_TypeError, "__format__() argument 1 must be str, not %s",
+                 Py_TYPE(format_spec)->tp_name);
+    return nullptr;
+  }
+  PyObject* i = PyIntN_nb_int<T>(self);
+  if (!i) {
+    return nullptr;
+  }
+  PyObject* result = PyObject_Format(i, format_spec);
+  Py_DECREF(i);
+  return result;
+}
+
+template <typename T>
+PyMethodDef IntNTypeDescriptor<T>::methods[] = {
+    {"__format__", reinterpret_cast<PyCFunction>(PyIntN_Format<T>), METH_O,
+     "Format a custom integer value."},
+    {nullptr, nullptr, 0, nullptr},
+};
+
 template <typename T>
 PyType_Slot IntNTypeDescriptor<T>::type_slots[] = {
     {Py_tp_new, reinterpret_cast<void*>(PyIntN_tp_new<T>)},
@@ -391,6 +416,7 @@ PyType_Slot IntNTypeDescriptor<T>::type_slots[] = {
     {Py_tp_doc,
      reinterpret_cast<void*>(const_cast<char*>(TypeDescriptor<T>::kTpDoc))},
     {Py_tp_richcompare, reinterpret_cast<void*>(PyIntN_RichCompare<T>)},
+    {Py_tp_methods, reinterpret_cast<void*>(IntNTypeDescriptor<T>::methods)},
     {Py_nb_add, reinterpret_cast<void*>(PyIntN_nb_add<T>)},
     {Py_nb_subtract, reinterpret_cast<void*>(PyIntN_nb_subtract<T>)},
     {Py_nb_multiply, reinterpret_cast<void*>(PyIntN_nb_multiply<T>)},

--- a/ml_dtypes/tests/custom_complex_test.py
+++ b/ml_dtypes/tests/custom_complex_test.py
@@ -139,6 +139,19 @@ def test_str_repr(sctype, value):
 
 @pytest.mark.parametrize("sctype", COMPLEX_SCTYPES)
 @pytest.mark.parametrize("value", COMPLEX_VALUES)
+def test_format(sctype, value):
+  z = sctype(value)
+  c = complex(z)
+  assert f"{z}" == f"{c}"
+  assert f"{z:.2f}" == f"{c:.2f}"
+  assert f"{z:.4e}" == f"{c:.4e}"
+  assert f"{z:.8}" == f"{c:.8}"
+  assert format(z, ".3g") == format(c, ".3g")
+  assert format(z) == format(c)
+
+
+@pytest.mark.parametrize("sctype", COMPLEX_SCTYPES)
+@pytest.mark.parametrize("value", COMPLEX_VALUES)
 def test_hash(sctype, value):
   # Test that we hash the same as NumPy (except for NaN)
   if not np.isnan(value):

--- a/ml_dtypes/tests/custom_float_test.py
+++ b/ml_dtypes/tests/custom_float_test.py
@@ -360,6 +360,18 @@ class CustomFloatTest(parameterized.TestCase):
           "%.6g" % float(float_type(value)), repr(float_type(value))
       )
 
+  def testFormat(self, float_type):
+    for value in FLOAT_VALUES[float_type]:
+      val = float_type(value)
+      f = float(val)
+      self.assertEqual(f"{val}", f"{f}")
+      self.assertEqual(f"{val:f}", f"{f:f}")
+      self.assertEqual(f"{val:.2f}", f"{f:.2f}")
+      self.assertEqual(f"{val:.4e}", f"{f:.4e}")
+      self.assertEqual(f"{val:.8}", f"{f:.8}")
+      self.assertEqual(format(val, ".3g"), format(f, ".3g"))
+      self.assertEqual(format(val), format(f))
+
   def testItem(self, float_type):
     self.assertIsInstance(float_type(0).item(), float)
 

--- a/ml_dtypes/tests/intn_test.py
+++ b/ml_dtypes/tests/intn_test.py
@@ -124,6 +124,20 @@ class ScalarTest(parameterized.TestCase):
       self.assertEqual(str(value), str(scalar_type(value)))
 
   @parameterized.product(scalar_type=INTN_TYPES)
+  def testFormat(self, scalar_type):
+    for value in VALUES[scalar_type]:
+      val = scalar_type(value)
+      self.assertEqual(f"{val}", f"{value}")
+      self.assertEqual(f"{val:d}", f"{value:d}")
+      self.assertEqual(f"{val:04d}", f"{value:04d}")
+      self.assertEqual(f"{val:x}", f"{value:x}")
+      self.assertEqual(f"{val:b}", f"{value:b}")
+      self.assertEqual(f"{val:o}", f"{value:o}")
+      self.assertEqual(f"{val:8d}", f"{value:8d}")
+      self.assertEqual(format(val, "x"), format(value, "x"))
+      self.assertEqual(format(val), format(value))
+
+  @parameterized.product(scalar_type=INTN_TYPES)
   def testItem(self, scalar_type):
     v = -1 if scalar_type == int1 else 1
     self.assertIsInstance(scalar_type(v).item(), int)


### PR DESCRIPTION
Fixes #341.

Previously, formatting custom dtypes (e.g. `f'{bfloat16(1e-6):.8}'`) would fall back to `np.generic.__format__`. Because NumPy's generic scalar formatter did not recognize custom dtypes as numeric scalar types, it converted them to strings and applied string formatting. This caused format specifiers to either truncate the string representation (cutting off exponent notation) or raise `ValueError: Unknown format code ... for object of type 'str'`.

This change adds `__format__` methods to custom float, complex, and integer types, which convert the scalar to a standard Python object (`float`, `complex`, `int`) and delegate to `PyObject_Format`.