### PR TITLE
Clean up scikit-build-core configuration in pyproject.toml.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ pyink-use-majority-quotes = true
 [build-system]
 requires = [
     "scikit-build-core",
-    "cmake>=3.15",
     # We build against the most recent supported NumPy 2.0 release;
     # see https://github.com/numpy/numpy/issues/27265
     "numpy~=2.0",
@@ -58,8 +57,14 @@ build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
 wheel.packages = ["ml_dtypes"]
+wheel.exclude = [
+    "ml_dtypes/_src",
+    "ml_dtypes/include",
+    "ml_dtypes/tests",
+]
 sdist.exclude = ["third_party/eigen/.git*"]
 
-[tool.scikit-build.metadata.version]
+[[tool.dynamic-metadata]]
 provider = "scikit_build_core.metadata.regex"
+field = "version"
 input = "ml_dtypes/__init__.py"


### PR DESCRIPTION
- Exclude _src, include, and tests directories from wheel builds.
- Remove cmake from build-system.requires: scikit-build-core automatically injects cmake into build requirements when not already present in the environment, and emits a warning if it is explicitly listed.
- Migrate tool.scikit-build.metadata.version to [[tool.dynamic-metadata]]: scikit-build-core 1.0+ deprecated the backend-specific metadata table in favor of the standard PEP 621 dynamic metadata array format.