### PR TITLE
Round exact ties to nearest-even when converting to float8_e8m0fnu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ To release a new version (e.g. from `1.0.0` -> `2.0.0`):
   `complex32` arrays on NumPy 2.5+ ([#383](https://github.com/jax-ml/ml_dtypes/pull/383)).
 * Fixed byte-swapping of `bcomplex32` and `complex32` arrays
   ([#383](https://github.com/jax-ml/ml_dtypes/pull/383)).
+* Fixed `float8_e8m0fnu` conversion to round exact ties to nearest-even instead
+  of always rounding up.
 
 ## [0.6.0] - 2026-08-13
 

--- a/ml_dtypes/include/float8.h
+++ b/ml_dtypes/include/float8.h
@@ -1263,7 +1263,8 @@ struct Traits<float8_e8m0fnu> : public TraitsBase<float8_e8m0fnu> {
 };
 
 template <typename Bits>
-constexpr inline Bits RoundBitsToNearestEven(Bits bits, int roundoff) {
+constexpr inline Bits RoundBitsToNearestEven(Bits bits, int roundoff,
+                                             bool last_kept_bit) {
   // Round to nearest even by adding a bias term.
   // Consider a bit pattern
   //   FFF...FLRTT...T,
@@ -1272,8 +1273,19 @@ constexpr inline Bits RoundBitsToNearestEven(Bits bits, int roundoff) {
   // - L is 1, R is 1, OR
   // - L is 0, R is 1, any T is one.
   // We do this by adding L to a bit pattern consisting of all T = 1.
-  Bits bias = ((bits >> roundoff) & 1) + (Bits{1} << (roundoff - 1)) - 1;
+  //
+  // L is the least-significant bit that is *kept* in the result. That is
+  // usually bit `roundoff` of `bits`, but a caller may pass a different value
+  // when that bit is not the result's LSB -- e.g. a mantissa-less target
+  // (E8M0) where the implicit bit carries into the exponent during packing, so
+  // the result's LSB is the exponent LSB, not bit `roundoff`.
+  Bits bias = Bits{last_kept_bit} + (Bits{1} << (roundoff - 1)) - 1;
   return bits + bias;
+}
+
+template <typename Bits>
+constexpr inline Bits RoundBitsToNearestEven(Bits bits, int roundoff) {
+  return RoundBitsToNearestEven(bits, roundoff, ((bits >> roundoff) & 1) != 0);
 }
 
 #if (defined(__cpp_lib_bitops) && __cpp_lib_bitops >= 201907L)
@@ -1462,8 +1474,23 @@ struct ConvertImpl<From, To, kSaturate, kTruncate,
       if constexpr (!kTruncate) {
         // Rounding may cause a carry (e.g., 1.11... -> 10.00...).
         // This carry will naturally flow into the exponent during packing.
-        normalized_mantissa =
-            RoundBitsToNearestEven(normalized_mantissa, alignment_shift);
+        if constexpr (kToMantissaBits == 0) {
+          // The target has no mantissa bits (E8M0). The implicit bit carries
+          // into the exponent during packing (Step 6), so the result's LSB is
+          // the truncated exponent's LSB, not bit `alignment_shift` of the
+          // mantissa (which is the always-1 implicit bit). Supply that bit
+          // explicitly so exact ties round to even rather than always up.
+          const ToBits trunc_exp_bits =
+              static_cast<ToBits>(std::max(0, target_biased_exponent_base));
+          const bool result_lsb =
+              (((normalized_mantissa >> alignment_shift) + trunc_exp_bits) &
+               1) != 0;
+          normalized_mantissa = RoundBitsToNearestEven(
+              normalized_mantissa, alignment_shift, result_lsb);
+        } else {
+          normalized_mantissa =
+              RoundBitsToNearestEven(normalized_mantissa, alignment_shift);
+        }
       }
       aligned_mantissa = normalized_mantissa >> alignment_shift;
     } else {

--- a/ml_dtypes/tests/float8_test.cc
+++ b/ml_dtypes/tests/float8_test.cc
@@ -430,6 +430,26 @@ TYPED_TEST(Float8Test, DownCasts) {
   }
 }
 
+// Regression test: converting to a mantissa-less target (E8M0) must round
+// exact ties to nearest-*even*, not always up. Previously the round-to-even
+// bit was read from the always-1 implicit mantissa bit, so every tie rounded
+// up. The tie 1.5 * 2^k is equidistant between 2^k and 2^(k+1); ties-to-even
+// selects the encoding whose LSB is 0.
+TEST(Float8E8m0Test, ConvertFromTiesToEven) {
+  auto rep = [](double x) {
+    return float8_e8m0fnu::ConvertFrom</*kSaturate=*/false,
+                                       /*kTruncate=*/false>(x)
+        .rep();
+  };
+  EXPECT_EQ(rep(3.0), 0x80);   // tie 2.0 (0x80, even) / 4.0 (0x81) -> 0x80
+  EXPECT_EQ(rep(0.75), 0x7E);  // tie 0.5 (0x7E, even) / 1.0 (0x7F) -> 0x7E
+  EXPECT_EQ(rep(6.0), 0x82);   // tie 4.0 (0x81) / 8.0 (0x82, even) -> 0x82
+  EXPECT_EQ(rep(12.0), 0x82);  // tie 8.0 (0x82, even) / 16.0 (0x83) -> 0x82
+  // Non-ties round to the nearest value.
+  EXPECT_EQ(rep(2.4), 0x80);  // nearer 2.0
+  EXPECT_EQ(rep(3.4), 0x81);  // nearer 4.0
+}
+
 TYPED_TEST(Float8Test, ConvertFromWithSaturation) {
   using Float8 = TypeParam;
 


### PR DESCRIPTION
### Summary

Converting a float/double/bfloat16 to `float8_e8m0fnu` — the mantissa-less, exponent-only scale type used by the MX formats — rounds every exact tie **up** instead of to **nearest-even**, contradicting the type's own rounding mode (`std::numeric_limits<float8_e8m0fnu>::round_style == round_to_nearest`) and the `RoundBitsToNearestEven` routine used for the conversion.

`3.0` is exactly halfway between the representable values `2.0` (`0x80`) and `4.0` (`0x81`); ties-to-even should select `2.0` (even encoding), but the code produces `4.0`. A sweep of all tie midpoints shows **126 of the 254** are mis-rounded (every tie whose nearest-even value is the smaller one).

```cpp
// before this fix:
float8_e8m0fnu::ConvertFrom<false, false>(3.0).rep()   // 0x81 (4.0); want 0x80 (2.0)
float8_e8m0fnu::ConvertFrom<false, false>(0.75).rep()  // 0x7F (1.0); want 0x7E (0.5)
```

### Cause

`RoundBitsToNearestEven(bits, roundoff)` derives the round-to-even ("last kept") bit as `(bits >> roundoff) & 1`. For a mantissa-less target `roundoff == kFromMantissaBits`, so that bit is the **always-1 implicit leading bit** — hence it is always 1 and every tie rounds up. The result's actual least-significant bit is the exponent LSB, into which the implicit bit carries during packing.

### Fix

Add an overload of `RoundBitsToNearestEven` that takes the last-kept bit explicitly (the existing two-argument form is unchanged and simply forwards the old default). In `ConvertImpl`, for `kToMantissaBits == 0`, supply the exponent LSB so exact ties round to even. Targets with mantissa bits are entirely unaffected.

### Testing

- New test `Float8E8m0Test.ConvertFromTiesToEven` checks that ties round to even (and non-ties to nearest).
- Verified directly against the header: all 254 e8m0 tie midpoints now round to the nearest-even encoding (was 126 mismatches), and a differential sweep of every cross-format `float8 -> float8` conversion is unchanged.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.